### PR TITLE
Added --emit-progress JSONL stream for external visualizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,26 @@ JSON (`--format json`) will give you the most detailed data. If you specify `--s
 
 You can also instantiate llama-benchy classes and run analysis directly from Python. See [Jupyter Notebook example](examples/benchmark_visualization.ipynb).
 
+## Live progress stream (for external visualizers)
+
+`--emit-progress PATH` writes a stream of newline-delimited JSON events to
+`PATH` (or `-` for stdout) while the benchmark runs. External visualizers —
+live TUIs, web dashboards, post-hoc analyzers — consume that stream and
+render whatever they like.
+
+```bash
+# Emit to a file alongside the normal benchmark
+llama-benchy --base-url http://localhost:8000/v1 --model … \
+             --emit-progress /tmp/progress.jsonl
+
+# Pipe straight into a visualizer (status output goes to stderr in this mode)
+llama-benchy --base-url http://localhost:8000/v1 --model … \
+             --emit-progress - | my-visualizer
+```
+
+Default behavior is unchanged when `--emit-progress` is omitted. Schema
+spec: [`docs/progress-schema.md`](docs/progress-schema.md).
+
 ## Development
 
 ### Running Integration Tests

--- a/docs/progress-schema.md
+++ b/docs/progress-schema.md
@@ -131,7 +131,11 @@ Emitted exactly once per request (including failed ones).
 Emitted exactly once at the end of the entire benchmark suite. Consumers
 SHOULD treat this as the final frame and exit cleanly.
 
-No additional fields beyond the common ones.
+| Field    | Type   | Notes                                                                                   |
+|----------|--------|-----------------------------------------------------------------------------------------|
+| `status` | string | `"ok"` — suite ran to completion. `"interrupted"` — Ctrl+C / SIGINT. `"error"` — unhandled exception. |
+
+Consumers SHOULD treat unknown `status` values as `"error"`.
 
 ## Ordering invariants
 
@@ -193,5 +197,5 @@ A two-token, single-request bench produces:
 {"schema":"llama-benchy-progress.v1","type":"tokens","ts":1714969500.911,"request_id":0,"count":1,"snippet":"Hello"}
 {"schema":"llama-benchy-progress.v1","type":"tokens","ts":1714969500.932,"request_id":0,"count":1,"snippet":" world"}
 {"schema":"llama-benchy-progress.v1","type":"request_end","ts":1714969500.945,"request_id":0,"total_tokens":2,"prompt_tokens":2048,"decode_seconds":0.055,"error":""}
-{"schema":"llama-benchy-progress.v1","type":"bench_complete","ts":1714969501.000}
+{"schema":"llama-benchy-progress.v1","type":"bench_complete","ts":1714969501.000,"status":"ok"}
 ```

--- a/docs/progress-schema.md
+++ b/docs/progress-schema.md
@@ -1,0 +1,197 @@
+# `--emit-progress` JSONL schema
+
+When llama-benchy is invoked with `--emit-progress PATH` (or
+`--emit-progress -` for stdout), it writes a stream of newline-delimited
+JSON events to PATH that an external visualizer can consume in real time.
+
+This document is the contract between llama-benchy (the producer) and any
+consumer (live TUIs, web dashboards, post-hoc analyzers). The producer
+side is intentionally tiny — no UI, no rendering, no visualization-specific
+dependencies — so consumers can be implemented in any language.
+
+## Versioning
+
+Every line carries a `schema` field with the value:
+
+```
+"llama-benchy-progress.v1"
+```
+
+Forward compatibility rules:
+
+- New fields may be added to existing event types without bumping the version.
+  Consumers MUST ignore unknown fields.
+- New event types may be added without bumping the version. Consumers SHOULD
+  ignore unknown `type` values.
+- Renaming or removing a field, or changing a field's semantics, requires
+  bumping the version (`v2`, `v3`, …). Consumers SHOULD reject lines whose
+  `schema` field they don't understand.
+
+## Common fields
+
+Every line is a JSON object with these fields:
+
+| Field    | Type   | Description                                    |
+|----------|--------|------------------------------------------------|
+| `schema` | string | Always `"llama-benchy-progress.v1"`.           |
+| `type`   | string | Event discriminator (see below).               |
+| `ts`     | number | Unix timestamp (seconds, fractional) at emit.  |
+
+## Event types
+
+### `header`
+
+Emitted once at the start of the run. Lets a consumer detect the schema
+version and the producer version before any data events arrive.
+
+| Field                  | Type   | Description                          |
+|------------------------|--------|--------------------------------------|
+| `llama_benchy_version` | string | Version string of the producer.      |
+
+### `request_start`
+
+Emitted by the runner before each individual HTTP request. One event per
+in-flight request; multiple may be in-flight simultaneously when the user
+configures concurrency > 1.
+
+| Field            | Type    | Description                                                            |
+|------------------|---------|------------------------------------------------------------------------|
+| `request_id`     | integer | Stable per-request identifier (monotonically increasing per process).  |
+| `model`          | string  | Model name as configured (e.g. `meta-llama/Llama-3.1-8B-Instruct`).    |
+| `base_url`       | string  | Endpoint URL the request is being sent to.                             |
+| `prompt_size`    | integer | User-facing `--pp` for this request (the value the user typed). The actual number of tokens sent to the server may differ slightly when llama-benchy's `--adapt-prompt` is on; see `prompt_tokens` on `request_end`. |
+| `response_size`  | integer | User-facing `--tg` for this request.                                   |
+| `context_size`   | integer | User-facing `--depth` for this request.                                |
+| `concurrency`    | integer | Concurrency level for this batch.                                      |
+| `run_index`      | integer | Zero-based run index within the current `(pp, tg, depth)` cell.        |
+| `target_label`   | string  | Optional human label; empty in v1 (reserved for future multi-target).  |
+
+### `request_first_response`
+
+Emitted the moment the first response chunk of any kind (even an empty
+role-only chunk) arrives for a given request. Distinct from
+`request_first_token` because some servers send an empty header chunk
+before the first content-bearing chunk.
+
+| Field        | Type    | Description                                                     |
+|--------------|---------|-----------------------------------------------------------------|
+| `request_id` | integer | Matches the request's `request_start`.                          |
+| `ttfr_s`     | number  | Time from request start to first response chunk (seconds).      |
+
+### `request_first_token`
+
+Emitted the moment the first content-bearing token arrives for a given
+request. This is `e2e_ttft` (end-to-end time to first token).
+
+| Field        | Type    | Description                                                     |
+|--------------|---------|-----------------------------------------------------------------|
+| `request_id` | integer | Matches the request's `request_start`.                          |
+| `ttft_s`     | number  | Time from request start to first content token (seconds, includes network). |
+
+### `latency_measured`
+
+Emitted once after llama-benchy completes its network-latency probe.
+Consumers use it to compute `est_ppt = ttfr − latency` (estimated pure
+prompt-processing time, with the network round-trip subtracted).
+
+| Field        | Type    | Description                                                     |
+|--------------|---------|-----------------------------------------------------------------|
+| `latency_s`  | number  | Measured / assumed network latency (seconds). Zero for `--latency-mode none`. |
+| `mode`       | string  | `"api"`, `"generation"`, or `"none"`.                           |
+
+### `tokens`
+
+Emitted per streaming chunk during decode. Multiple `tokens` events occur
+between `request_first_token` and `request_end`.
+
+| Field        | Type    | Description                                            |
+|--------------|---------|--------------------------------------------------------|
+| `request_id` | integer | Matches the request's `request_start`.                 |
+| `count`      | integer | Number of generated tokens in this chunk (≥ 1).        |
+| `snippet`    | string  | Decoded text for this chunk (may be empty).            |
+
+A single `tokens` event may carry multiple tokens when the server streams
+multi-token chunks (e.g. speculative decoding / MTP). Consumers computing
+tok/s should sum `count` across events, not assume one-per-event.
+
+### `request_end`
+
+Emitted exactly once per request (including failed ones).
+
+| Field            | Type    | Description                                                        |
+|------------------|---------|--------------------------------------------------------------------|
+| `request_id`     | integer | Matches the request's `request_start`.                             |
+| `total_tokens`   | integer | Total generated tokens for this request.                           |
+| `prompt_tokens`  | integer | Server-reported prompt token count (0 if the server didn't say).   |
+| `decode_seconds` | number  | Time from `first_token_ts` to request end (seconds).               |
+| `error`          | string  | Empty on success, otherwise the error message.                     |
+
+### `bench_complete`
+
+Emitted exactly once at the end of the entire benchmark suite. Consumers
+SHOULD treat this as the final frame and exit cleanly.
+
+No additional fields beyond the common ones.
+
+## Ordering invariants
+
+For any single `request_id`:
+
+1. `request_start` always precedes any other event for that id.
+2. `request_first_response` (if it fires at all) precedes
+   `request_first_token`, all `tokens`, and `request_end` for that id.
+3. `request_first_token` (if it fires at all) precedes any `tokens` and
+   `request_end` for that id, and follows `request_first_response`.
+4. `tokens` events for a given id arrive in stream order (chunk by chunk).
+5. `request_end` is the last event for that id.
+
+Across requests, `latency_measured` fires once per benchmark run, before
+any `request_start` events.
+
+Across requests:
+
+- `request_id` values are strictly monotonic per process (not sparse, not
+  reused). Consumers can rely on the fact that a higher id was started
+  later than a lower id.
+- `request_start` events for concurrent requests can interleave with each
+  other and with `tokens` / `request_end` events of earlier requests.
+- `bench_complete` is always the last event in the stream.
+
+## Stream destination
+
+`--emit-progress PATH` writes to `PATH`, line-buffered.
+
+`--emit-progress -` writes to stdout. To prevent llama-benchy's normal
+status output from corrupting the JSONL stream, in this mode all status
+prints are routed to stderr instead. Pipe consumers can rely on stdout
+being clean JSONL.
+
+## What's *not* in v1
+
+By design, v1 does NOT include:
+
+- Hardware metrics (GPU%, VRAM, RAM, temp, power). Visualizers can sample
+  these on their own from the host they're running on.
+- Aggregate / smoothed throughput. Consumers compute this themselves
+  (rolling window over `tokens.count`).
+- Phase labels (`PREFILL` / `DECODE` / `DONE`). Phases are derivable: a
+  request is `PREFILL` between `request_start` and `request_first_token`,
+  `DECODE` between `request_first_token` and `request_end`, and
+  `DONE`/`ERROR` after `request_end`.
+- Display modes / chart settings / colors. Those are visualizer concerns.
+
+These may appear in a later schema version if a real consumer needs them.
+
+## Example
+
+A two-token, single-request bench produces:
+
+```jsonl
+{"schema":"llama-benchy-progress.v1","type":"header","ts":1714969500.123,"llama_benchy_version":"0.3.8"}
+{"schema":"llama-benchy-progress.v1","type":"request_start","ts":1714969500.456,"request_id":0,"model":"meta-llama/Llama-3.1-8B-Instruct","base_url":"http://localhost:8000/v1","prompt_size":2048,"response_size":2,"context_size":0,"concurrency":1,"run_index":0,"target_label":""}
+{"schema":"llama-benchy-progress.v1","type":"request_first_token","ts":1714969500.890,"request_id":0,"ttft_s":0.434}
+{"schema":"llama-benchy-progress.v1","type":"tokens","ts":1714969500.911,"request_id":0,"count":1,"snippet":"Hello"}
+{"schema":"llama-benchy-progress.v1","type":"tokens","ts":1714969500.932,"request_id":0,"count":1,"snippet":" world"}
+{"schema":"llama-benchy-progress.v1","type":"request_end","ts":1714969500.945,"request_id":0,"total_tokens":2,"prompt_tokens":2048,"decode_seconds":0.055,"error":""}
+{"schema":"llama-benchy-progress.v1","type":"bench_complete","ts":1714969501.000}
+```

--- a/docs/progress-schema.md
+++ b/docs/progress-schema.md
@@ -109,6 +109,7 @@ between `request_first_token` and `request_end`.
 | `request_id` | integer | Matches the request's `request_start`.                 |
 | `count`      | integer | Number of generated tokens in this chunk (≥ 1).        |
 | `snippet`    | string  | Decoded text for this chunk (may be empty).            |
+| `estimated`  | boolean | Optional. Present and `true` when the server did not return `token_ids` and `count` is a best-effort estimate (one-per-chunk fallback). Absent otherwise. The authoritative total is reported on `request_end`. |
 
 A single `tokens` event may carry multiple tokens when the server streams
 multi-token chunks (e.g. speculative decoding / MTP). Consumers computing

--- a/src/llama_benchy/__main__.py
+++ b/src/llama_benchy/__main__.py
@@ -11,11 +11,17 @@ from .corpus import TokenizedCorpus
 from .prompts import PromptGenerator
 from .client import LLMClient
 from .runner import BenchmarkRunner
+from .progress import ProgressEmitter
 
 async def main_async():
     # 1. Parse Configuration
     config = BenchmarkConfig.from_args()
-    
+
+    # 1b. If JSONL is going to stdout, route llama-benchy's status prints to
+    # stderr so they don't corrupt the JSONL stream a consumer is parsing.
+    if config.emit_progress == "-":
+        sys.stdout = sys.stderr
+
     # 2. Print Header
     current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     print(f"llama-benchy ({__version__})")
@@ -26,7 +32,7 @@ async def main_async():
     # 3. Prepare Data
     corpus = TokenizedCorpus(config.book_url, config.tokenizer, config.model)
     print(f"Total tokens available in text corpus: {len(corpus)}")
-    
+
     # 4. Initialize Components
     prompt_gen = PromptGenerator(corpus)
     client = LLMClient(
@@ -36,11 +42,22 @@ async def main_async():
         config.extra_body,
         config.exact_tg,
     )
-    runner = BenchmarkRunner(config, client, prompt_gen)
-    
+
+    progress = None
+    if config.emit_progress:
+        progress = ProgressEmitter(config.emit_progress, llama_benchy_version=__version__)
+    runner = BenchmarkRunner(config, client, prompt_gen, progress=progress)
+
     # 5. Run Benchmark Suite
-    await runner.run_suite()
-    
+    try:
+        await runner.run_suite()
+    finally:
+        if progress is not None:
+            try:
+                progress.bench_complete()
+            finally:
+                progress.close()
+
     print(f"\nllama-benchy ({__version__})")
     print(f"date: {current_time} | latency mode: {config.latency_mode}")
 

--- a/src/llama_benchy/__main__.py
+++ b/src/llama_benchy/__main__.py
@@ -49,12 +49,19 @@ async def main_async():
     runner = BenchmarkRunner(config, client, prompt_gen, progress=progress)
 
     # 5. Run Benchmark Suite
+    status = "ok"
     try:
         await runner.run_suite()
+    except KeyboardInterrupt:
+        status = "interrupted"
+        raise
+    except BaseException:
+        status = "error"
+        raise
     finally:
         if progress is not None:
             try:
-                progress.bench_complete()
+                progress.bench_complete(status=status)
             finally:
                 progress.close()
 

--- a/src/llama_benchy/client.py
+++ b/src/llama_benchy/client.py
@@ -272,13 +272,15 @@ class LLMClient:
         return delta_user, delta_context
 
     async def run_generation(
-            self, 
-            session: aiohttp.ClientSession, 
-            context_text: str, 
-            prompt_text: str, 
-            max_tokens: int, 
+            self,
+            session: aiohttp.ClientSession,
+            context_text: str,
+            prompt_text: str,
+            max_tokens: int,
             no_cache: bool,
-            tokenizer=None
+            tokenizer=None,
+            progress=None,
+            request_id: Optional[int] = None,
         ) -> RequestResult:
 
         messages = []
@@ -298,6 +300,7 @@ class LLMClient:
                     error_text = await response.text()
                     result.error = f"HTTP {response.status}: {error_text}"
                     print(result.error)
+                    self._emit_request_end(progress, request_id, result)
                     return result
 
                 decoder = codecs.getincrementaldecoder("utf-8")(errors='replace')
@@ -336,16 +339,32 @@ class LLMClient:
                                 if 'choices' in chunk and len(chunk['choices']) > 0:
                                     if result.first_response_ts is None:
                                         result.first_response_ts = chunk_time
+                                        if progress is not None and request_id is not None:
+                                            try:
+                                                progress.request_first_response(
+                                                    request_id=request_id,
+                                                    ttfr_s=chunk_time - result.start_ts,
+                                                )
+                                            except Exception:
+                                                pass
 
                                     delta = chunk['choices'][0].get('delta', {})
                                     content = delta.get('content')
                                     reasoning_content = delta.get('reasoning_content')
                                     reasoning = delta.get('reasoning')
-                                    
+
                                     if content or reasoning_content or reasoning:
                                         if result.first_token_ts is None:
                                             result.first_token_ts = chunk_time
-                                        
+                                            if progress is not None and request_id is not None:
+                                                try:
+                                                    progress.request_first_token(
+                                                        request_id=request_id,
+                                                        ttft_s=chunk_time - result.start_ts,
+                                                    )
+                                                except Exception:
+                                                    pass
+
                                         token_ids = chunk['choices'][0].get('token_ids')
                                         text = content or reasoning_content or reasoning
                                         content_chunks.append({
@@ -353,6 +372,20 @@ class LLMClient:
                                             "timestamp": chunk_time,
                                             "token_ids": token_ids,
                                         })
+
+                                        if progress is not None and request_id is not None:
+                                            # Best-effort per-chunk count for the live stream.
+                                            # The authoritative total is reconciled in
+                                            # _finalize_stream_tokens and reported by request_end.
+                                            chunk_count = len(token_ids) if isinstance(token_ids, list) else 1
+                                            try:
+                                                progress.tokens(
+                                                    request_id=request_id,
+                                                    count=chunk_count,
+                                                    snippet=text or "",
+                                                )
+                                            except Exception:
+                                                pass
                             except json.JSONDecodeError:
                                 continue
 
@@ -362,5 +395,25 @@ class LLMClient:
         except Exception as e:
             print(f"Error during run: {e}")
             result.error = str(e)
-        
+
+        self._emit_request_end(progress, request_id, result)
         return result
+
+    @staticmethod
+    def _emit_request_end(progress, request_id: Optional[int], result: "RequestResult") -> None:
+        """Emit the request_end progress event for a finished request."""
+        if progress is None or request_id is None:
+            return
+        decode_seconds = 0.0
+        if result.first_token_ts is not None and result.end_ts:
+            decode_seconds = max(0.0, result.end_ts - result.first_token_ts)
+        try:
+            progress.request_end(
+                request_id=request_id,
+                total_tokens=result.total_tokens,
+                prompt_tokens=result.prompt_tokens,
+                decode_seconds=decode_seconds,
+                error=result.error or "",
+            )
+        except Exception:
+            pass

--- a/src/llama_benchy/client.py
+++ b/src/llama_benchy/client.py
@@ -377,12 +377,14 @@ class LLMClient:
                                             # Best-effort per-chunk count for the live stream.
                                             # The authoritative total is reconciled in
                                             # _finalize_stream_tokens and reported by request_end.
-                                            chunk_count = len(token_ids) if isinstance(token_ids, list) else 1
+                                            has_token_ids = isinstance(token_ids, list)
+                                            chunk_count = len(token_ids) if has_token_ids else 1
                                             try:
                                                 progress.tokens(
                                                     request_id=request_id,
                                                     count=chunk_count,
                                                     snippet=text or "",
+                                                    estimated=not has_token_ids,
                                                 )
                                             except Exception:
                                                 pass

--- a/src/llama_benchy/config.py
+++ b/src/llama_benchy/config.py
@@ -74,6 +74,10 @@ class BenchmarkConfig(BaseModel):
         default_factory=dict,
         description="Extra JSON fields to merge into benchmark chat completion requests",
     )
+    emit_progress: Optional[str] = Field(
+        None,
+        description="Emit progress events as JSONL to PATH (or '-' for stdout). See docs/progress-schema.md.",
+    )
 
     @staticmethod
     def _parse_extra_body(values: Optional[List[str]]) -> Dict[str, Any]:
@@ -354,6 +358,17 @@ class BenchmarkConfig(BaseModel):
             default=[],
             help="Extra JSON fields to merge into benchmark chat completion requests. Accepts key=value or key:value, comma-separated or repeated.",
         )
+        parser.add_argument(
+            "--emit-progress",
+            type=str,
+            default=None,
+            metavar="PATH",
+            help=(
+                "Emit benchmark progress events as JSONL to PATH (or '-' for stdout). "
+                "External visualizers (live TUIs, web dashboards, post-hoc charts) "
+                "consume this stream. Schema: docs/progress-schema.md."
+            ),
+        )
 
         args = parser.parse_args()
 
@@ -416,4 +431,5 @@ class BenchmarkConfig(BaseModel):
             exit_on_first_fail=args.exit_on_first_fail,
             no_results_on_fail=args.no_results_on_fail,
             extra_body=extra_body,
+            emit_progress=args.emit_progress,
         )

--- a/src/llama_benchy/progress.py
+++ b/src/llama_benchy/progress.py
@@ -119,8 +119,8 @@ class ProgressEmitter:
             error=error,
         )
 
-    def bench_complete(self) -> None:
-        self._emit("bench_complete")
+    def bench_complete(self, status: str = "ok") -> None:
+        self._emit("bench_complete", status=status)
 
     def close(self) -> None:
         with self._lock:

--- a/src/llama_benchy/progress.py
+++ b/src/llama_benchy/progress.py
@@ -1,0 +1,165 @@
+"""Optional progress-event emitter for llama-benchy.
+
+When the user passes ``--emit-progress PATH``, llama-benchy writes a stream
+of newline-delimited JSON events to PATH (or stdout when PATH is ``-``).
+Consumers — separate tools, e.g. live TUIs, web dashboards, post-hoc
+visualizers — parse that stream and render whatever they like.
+
+Schema spec:        docs/progress-schema.md
+Schema version tag: ``llama-benchy-progress.v1``
+
+This module is intentionally small. It carries no UI, no rendering, no
+optional deps. Anything fancier lives in a separate consumer repo.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+from typing import IO, Optional
+
+SCHEMA_VERSION = "llama-benchy-progress.v1"
+
+
+class ProgressEmitter:
+    """Append-only JSONL writer for benchmark progress events.
+
+    Thread-safe (a lock guards the underlying file write). Methods are
+    no-throwing — emit failures are silently dropped so a broken consumer
+    can't take down a benchmark run.
+    """
+
+    def __init__(self, target: str, *, llama_benchy_version: str = "unknown") -> None:
+        self._target = target
+        self._lock = threading.Lock()
+        self._stream: Optional[IO[str]] = None
+        self._owns_stream = False
+        self._open(llama_benchy_version)
+
+    def _open(self, llama_benchy_version: str) -> None:
+        if self._target == "-":
+            # Caller is expected to have already redirected sys.stdout to
+            # sys.stderr (see __main__) so llama-benchy's regular status
+            # prints don't corrupt the JSONL stream we emit here.
+            self._stream = sys.__stdout__
+            self._owns_stream = False
+        else:
+            self._stream = open(self._target, "w", buffering=1)  # line-buffered
+            self._owns_stream = True
+        self._write(
+            {
+                "schema": SCHEMA_VERSION,
+                "type": "header",
+                "ts": time.time(),
+                "llama_benchy_version": llama_benchy_version,
+            }
+        )
+
+    # event API
+    def request_start(
+        self,
+        *,
+        request_id: int,
+        model: str,
+        base_url: str,
+        prompt_size: int,
+        response_size: int,
+        context_size: int,
+        concurrency: int,
+        run_index: int,
+        target_label: str = "",
+    ) -> None:
+        self._emit(
+            "request_start",
+            request_id=request_id,
+            model=model,
+            base_url=base_url,
+            prompt_size=prompt_size,
+            response_size=response_size,
+            context_size=context_size,
+            concurrency=concurrency,
+            run_index=run_index,
+            target_label=target_label,
+        )
+
+    def request_first_response(self, *, request_id: int, ttfr_s: float) -> None:
+        """First chunk of any kind arrived (may be empty / role-only)."""
+        self._emit("request_first_response", request_id=request_id, ttfr_s=ttfr_s)
+
+    def request_first_token(self, *, request_id: int, ttft_s: float) -> None:
+        """First content-bearing token arrived (== e2e_ttft)."""
+        self._emit("request_first_token", request_id=request_id, ttft_s=ttft_s)
+
+    def latency_measured(self, *, latency_s: float, mode: str) -> None:
+        """Network latency probe complete (used to derive est_ppt = ttfr − latency)."""
+        self._emit("latency_measured", latency_s=latency_s, mode=mode)
+
+    def tokens(self, *, request_id: int, count: int, snippet: str = "") -> None:
+        if count <= 0 and not snippet:
+            return
+        self._emit("tokens", request_id=request_id, count=count, snippet=snippet)
+
+    def request_end(
+        self,
+        *,
+        request_id: int,
+        total_tokens: int,
+        prompt_tokens: int,
+        decode_seconds: float,
+        error: str = "",
+    ) -> None:
+        self._emit(
+            "request_end",
+            request_id=request_id,
+            total_tokens=total_tokens,
+            prompt_tokens=prompt_tokens,
+            decode_seconds=decode_seconds,
+            error=error,
+        )
+
+    def bench_complete(self) -> None:
+        self._emit("bench_complete")
+
+    def close(self) -> None:
+        with self._lock:
+            if self._stream is not None and self._owns_stream:
+                try:
+                    self._stream.close()
+                except Exception:
+                    pass
+            self._stream = None
+
+    def __enter__(self) -> "ProgressEmitter":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    # internals
+    def _emit(self, event_type: str, **fields) -> None:
+        self._write(
+            {
+                "schema": SCHEMA_VERSION,
+                "type": event_type,
+                "ts": time.time(),
+                **fields,
+            }
+        )
+
+    def _write(self, obj: dict) -> None:
+        if self._stream is None:
+            return
+        try:
+            line = json.dumps(obj, separators=(",", ":"))
+        except (TypeError, ValueError):
+            return
+        with self._lock:
+            try:
+                self._stream.write(line)
+                self._stream.write("\n")
+                self._stream.flush()
+            except Exception:
+                # Consumer hung up / disk full — don't crash the benchmark.
+                pass

--- a/src/llama_benchy/progress.py
+++ b/src/llama_benchy/progress.py
@@ -96,10 +96,13 @@ class ProgressEmitter:
         """Network latency probe complete (used to derive est_ppt = ttfr − latency)."""
         self._emit("latency_measured", latency_s=latency_s, mode=mode)
 
-    def tokens(self, *, request_id: int, count: int, snippet: str = "") -> None:
+    def tokens(self, *, request_id: int, count: int, snippet: str = "", estimated: bool = False) -> None:
         if count <= 0 and not snippet:
             return
-        self._emit("tokens", request_id=request_id, count=count, snippet=snippet)
+        fields = {"request_id": request_id, "count": count, "snippet": snippet}
+        if estimated:
+            fields["estimated"] = True
+        self._emit("tokens", **fields)
 
     def request_end(
         self,

--- a/src/llama_benchy/runner.py
+++ b/src/llama_benchy/runner.py
@@ -16,15 +16,40 @@ class BenchmarkFailure(Exception):
     pass
 
 class BenchmarkRunner:
-    def __init__(self, config: BenchmarkConfig, client: LLMClient, prompt_generator: PromptGenerator):
+    def __init__(self, config: BenchmarkConfig, client: LLMClient, prompt_generator: PromptGenerator, progress=None):
         self.config = config
         self.client = client
         self.prompt_gen = prompt_generator
         self.results = BenchmarkResults()
+        self.progress = progress
+        self._next_request_id = 0
 
         # We need to track deltas from warmup to adapt prompts
         self.delta_user = 0
         self.delta_context = 0
+
+    def _new_request_id(self) -> int:
+        rid = self._next_request_id
+        self._next_request_id += 1
+        return rid
+
+    def _emit_request_start(self, request_id: int, pp: int, tg: int, depth: int, concurrency: int, run_index: int) -> None:
+        if self.progress is None:
+            return
+        try:
+            self.progress.request_start(
+                request_id=request_id,
+                model=self.config.model,
+                base_url=self.config.base_url,
+                prompt_size=pp,
+                response_size=tg,
+                context_size=depth,
+                concurrency=concurrency,
+                run_index=run_index,
+                target_label="",
+            )
+        except Exception:
+            pass
 
     async def run_suite(self):
         # Initialize session
@@ -55,6 +80,13 @@ class BenchmarkRunner:
 
                 # Measure latency
                 latency = await self.client.measure_latency(session, self.config.latency_mode)
+                if self.progress is not None:
+                    try:
+                        self.progress.latency_measured(
+                            latency_s=latency, mode=self.config.latency_mode
+                        )
+                    except Exception:
+                        pass
 
                 # Main Loop
                 for depth in self.config.depths:
@@ -98,13 +130,18 @@ class BenchmarkRunner:
                                         load_tasks = []
                                         for i in range(concurrency):
                                             context, _ = prompt_batch[i]
+                                            rid = self._new_request_id()
+                                            if not is_warmup:
+                                                self._emit_request_start(rid, pp, tg, depth, concurrency, run)
                                             load_tasks.append(self.client.run_generation(
                                                 session,
                                                 context_text=context,
                                                 prompt_text="",
                                                 max_tokens=tg,
                                                 no_cache=self.config.no_cache,
-                                                tokenizer=tokenizer
+                                                tokenizer=tokenizer,
+                                                progress=None if is_warmup else self.progress,
+                                                request_id=None if is_warmup else rid,
                                             ))
 
                                         load_results = await asyncio.gather(*load_tasks)
@@ -121,13 +158,18 @@ class BenchmarkRunner:
                                         inf_tasks = []
                                         for i in range(concurrency):
                                             context, prompt = prompt_batch[i]
+                                            rid = self._new_request_id()
+                                            if not is_warmup:
+                                                self._emit_request_start(rid, pp, tg, depth, concurrency, run)
                                             inf_tasks.append(self.client.run_generation(
                                                 session,
                                                 context_text=context,
                                                 prompt_text=prompt,
                                                 max_tokens=tg,
                                                 no_cache=self.config.no_cache,
-                                                tokenizer=tokenizer
+                                                tokenizer=tokenizer,
+                                                progress=None if is_warmup else self.progress,
+                                                request_id=None if is_warmup else rid,
                                             ))
 
                                         batch_results = await asyncio.gather(*inf_tasks)
@@ -146,13 +188,18 @@ class BenchmarkRunner:
                                         batch_tasks = []
                                         for i in range(concurrency):
                                             context, prompt = prompt_batch[i]
+                                            rid = self._new_request_id()
+                                            if not is_warmup:
+                                                self._emit_request_start(rid, pp, tg, depth, concurrency, run)
                                             batch_tasks.append(self.client.run_generation(
                                                 session,
                                                 context_text=context,
                                                 prompt_text=prompt,
                                                 max_tokens=tg,
                                                 no_cache=self.config.no_cache,
-                                                tokenizer=tokenizer
+                                                tokenizer=tokenizer,
+                                                progress=None if is_warmup else self.progress,
+                                                request_id=None if is_warmup else rid,
                                             ))
 
                                         batch_results = await asyncio.gather(*batch_tasks)

--- a/src/llama_benchy/runner.py
+++ b/src/llama_benchy/runner.py
@@ -130,8 +130,8 @@ class BenchmarkRunner:
                                         load_tasks = []
                                         for i in range(concurrency):
                                             context, _ = prompt_batch[i]
-                                            rid = self._new_request_id()
                                             if not is_warmup:
+                                                rid = self._new_request_id()
                                                 self._emit_request_start(rid, pp, tg, depth, concurrency, run)
                                             load_tasks.append(self.client.run_generation(
                                                 session,
@@ -158,8 +158,8 @@ class BenchmarkRunner:
                                         inf_tasks = []
                                         for i in range(concurrency):
                                             context, prompt = prompt_batch[i]
-                                            rid = self._new_request_id()
                                             if not is_warmup:
+                                                rid = self._new_request_id()
                                                 self._emit_request_start(rid, pp, tg, depth, concurrency, run)
                                             inf_tasks.append(self.client.run_generation(
                                                 session,
@@ -188,8 +188,8 @@ class BenchmarkRunner:
                                         batch_tasks = []
                                         for i in range(concurrency):
                                             context, prompt = prompt_batch[i]
-                                            rid = self._new_request_id()
                                             if not is_warmup:
+                                                rid = self._new_request_id()
                                                 self._emit_request_start(rid, pp, tg, depth, concurrency, run)
                                             batch_tasks.append(self.client.run_generation(
                                                 session,


### PR DESCRIPTION
## Summary

Add an opt-in `--emit-progress PATH` flag that writes a stream of newline-delimited JSON events while the benchmark runs. External visualizers — live TUIs, web dashboards, post-hoc analyzers — consume the stream and render whatever they like. Default behavior is unchanged when the flag is omitted.

## What's in this PR

- **CLI flag** `--emit-progress PATH` (or `-` for stdout). When the target is stdout, llama-benchy's status prints are routed to stderr so they don't corrupt the JSONL stream a consumer is parsing.
- **New module** `src/llama_benchy/progress.py` — a small, thread-safe, no-throwing JSONL writer. No UI / rendering / optional deps. Emit failures are silently dropped so a broken consumer can't take down a benchmark run.
- **Wired into `runner.py`** — `request_start`, `latency_measured`, `bench_complete`.
- **Wired into `client.py`** — `request_first_response`, `request_first_token`, per-chunk `tokens` (with optional snippet), `request_end` with timing + token totals.
- **Schema spec** in `docs/progress-schema.md` with explicit forward-compatibility rules:
  - Tag: `llama-benchy-progress.v1`
  - New fields and event types may be added without bumping the version; consumers MUST ignore unknown fields and SHOULD ignore unknown `type` values.
  - Renaming or removing a field, or changing semantics, requires `v2`.
- **README section** pointing at the schema doc.

## Why

llama-benchy's existing output is great for post-run analysis but doesn't expose the inner timing of a run as it happens (TTFT, TTFR, per-chunk arrival times, latency-mode timing). Adding this as a structured opt-in stream — rather than building any specific visualizer into llama-benchy itself — keeps the producer side small and lets the ecosystem build whatever consumers it likes.

A reference consumer exists at https://github.com/alexziskind1/llama-benchy-viz-tui — a Rich-based live TUI dashboard with single-model and multi-model race modes. It uses only the v1 schema and is independent of this repo (the schema is the contract).

## Backwards compatibility

- Flag is opt-in; with `--emit-progress` omitted, llama-benchy's behavior is byte-identical to before.
- No changes to existing flags, output formats, or library API.
- Producer side carries no optional dependencies.

## Test plan

- [x] Default behavior unchanged when flag omitted
- [x] `--emit-progress -` routes status prints to stderr; stdout is pure JSONL
- [x] `--emit-progress /tmp/p.jsonl` writes the file alongside the normal run
- [x] All event types (header, request_start, request_first_response, request_first_token, tokens, request_end, latency_measured, bench_complete) verified end-to-end against the reference visualizer
- [x] Verified across single-model, multi-cell sweeps, multi-run aggregation, and concurrent multi-model runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)