### PR TITLE
added flag --progress-bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ coverage.xml
 examples/*.json
 
 graphify-out/
+
+# Benchmark results
+results.json

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@ coverage.xml
 *.swo
 *~
 examples/*.json
+
+graphify-out/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ As of January 2nd, 2026, I wasn't able to find any existing benchmarking tool th
 - Can save granular time-series data for token generation when JSON output is used (`--save-total-throughput-timeseries` and `--save-all-throughput-timeseries`).
 - Runs a coherence test after warmup to verify model responds correctly (default, can be skipped with `--skip-coherence`).
 - Auto-detects HuggingFace model name from the endpoint's `/models` endpoint when `--model` is not specified.
+- Shows a weighted progress bar with ETA during benchmark execution (`--progress-bar`).
 
 # Current Limitations
 
@@ -183,6 +184,7 @@ Generally you don't need to disable prompt caching on the server, as a probabili
 -   `--exit-on-first-fail`: Stop execution on first failed test and exit with non-zero status.
 -   `--no-results-on-fail`: Prevent saving/printing any results when error is experienced, turns on --exit-on-first-fail as well.
 -   `--extra-body`: Extra JSON fields to merge into benchmark chat completion requests. Accepts repeated or comma-separated `key=value` / `key:value` entries, e.g. `--extra-body min_tokens=1024,ignore_eos=true`.
+-   `--progress-bar`: Show a weighted console progress bar with ETA during benchmark execution. Progress is weighted by estimated token-processing cost (prompt tokens × prompt cost + generation tokens × generation cost), so larger configurations contribute proportionally more progress. ETA is refined adaptively using actual phase timings.
 
 For fixed-output-length throughput benchmarks, prefer `--exact-tg` over manually passing `min_tokens` and `ignore_eos`:
 

--- a/src/llama_benchy/config.py
+++ b/src/llama_benchy/config.py
@@ -82,6 +82,10 @@ class BenchmarkConfig(BaseModel):
         None,
         description="Emit progress events as JSONL to PATH (or '-' for stdout). See docs/progress-schema.md.",
     )
+    progress_bar: bool = Field(
+        False,
+        description="Show a simple console progress bar with ETA during benchmark execution.",
+    )
 
     @staticmethod
     def _parse_extra_body(values: Optional[List[str]]) -> Dict[str, Any]:
@@ -383,6 +387,11 @@ class BenchmarkConfig(BaseModel):
                 "consume this stream. Schema: docs/progress-schema.md."
             ),
         )
+        parser.add_argument(
+            "--progress-bar",
+            action="store_true",
+            help="Show a simple console progress bar with ETA while the benchmark runs.",
+        )
 
         args = parser.parse_args()
 
@@ -449,4 +458,5 @@ class BenchmarkConfig(BaseModel):
             no_results_on_fail=args.no_results_on_fail,
             extra_body=extra_body,
             emit_progress=args.emit_progress,
+            progress_bar=args.progress_bar,
         )

--- a/src/llama_benchy/progress.py
+++ b/src/llama_benchy/progress.py
@@ -23,6 +23,70 @@ from typing import IO, Optional
 SCHEMA_VERSION = "llama-benchy-progress.v1"
 
 
+class ConsoleProgressBar:
+    """Simple console progress indicator with ETA for benchmark phases."""
+
+    def __init__(self, total_steps: int, *, enabled: bool = False, stream: Optional[IO[str]] = None) -> None:
+        self.total_steps = max(0, total_steps)
+        self.enabled = enabled
+        self.stream = stream or sys.stdout
+        self._started_at: Optional[float] = None
+
+    def start(self) -> None:
+        if not self.enabled:
+            return
+        self._started_at = time.perf_counter()
+
+    def render(self, current_step: int, *, description: str = "", total_steps: Optional[int] = None, elapsed: Optional[float] = None) -> None:
+        if not self.enabled:
+            return
+
+        total = self.total_steps if total_steps is None else max(0, total_steps)
+        if total <= 0:
+            return
+
+        current = max(0, min(current_step, total))
+        if self._started_at is None:
+            self._started_at = time.perf_counter()
+
+        elapsed = time.perf_counter() - self._started_at if elapsed is None else elapsed
+        completed = max(0, current)
+        percent = (completed / total) * 100 if total else 0
+        filled_width = 24
+        filled = int((completed / total) * filled_width) if total else 0
+        bar = "[" + "=" * filled + (">" if completed < total and filled < filled_width else "") + "-" * max(0, filled_width - filled - (1 if completed < total and filled < filled_width else 0)) + "]"
+
+        if completed > 0 and elapsed > 0:
+            eta_seconds = elapsed * (total - completed) / completed
+            eta_text = self._format_duration(eta_seconds)
+        else:
+            eta_text = "--:--"
+
+        message = f"{bar} {completed}/{total} {description} | {percent:3.0f}% | ETA {eta_text}".rstrip()
+        self.stream.write("\r\033[K")
+        self.stream.write(message)
+        self.stream.flush()
+
+    def finish(self, message: Optional[str] = None) -> None:
+        if not self.enabled:
+            return
+        if message:
+            self.stream.write("\r\033[K")
+            self.stream.write(f"{message}\n")
+        else:
+            self.stream.write("\r\033[K\n")
+        self.stream.flush()
+
+    @staticmethod
+    def _format_duration(seconds: float) -> str:
+        total_seconds = max(0, int(seconds))
+        minutes, sec = divmod(total_seconds, 60)
+        hours, minutes = divmod(minutes, 60)
+        if hours:
+            return f"{hours:02d}:{minutes:02d}:{sec:02d}"
+        return f"{minutes:02d}:{sec:02d}"
+
+
 class ProgressEmitter:
     """Append-only JSONL writer for benchmark progress events.
 

--- a/src/llama_benchy/progress.py
+++ b/src/llama_benchy/progress.py
@@ -18,54 +18,157 @@ import json
 import sys
 import threading
 import time
-from typing import IO, Optional
+from typing import IO, List, Optional, Tuple
 
 SCHEMA_VERSION = "llama-benchy-progress.v1"
 
+# Relative cost weights for prompt-processing tokens vs. generation tokens.
+# Prompt processing (prefill) is typically much faster per token than
+# token generation (decode) on modern LLM servers. These defaults reflect
+# a typical ratio (~20x), but the WeightedProgressTracker allows callers to
+# override them. The key invariant: GEN_COST > PROMPT_COST, so generation
+# workloads contribute proportionally more progress than prompt workloads.
+DEFAULT_PROMPT_COST = 1.0
+DEFAULT_GEN_COST = 20.0
+
 
 class ConsoleProgressBar:
-    """Simple console progress indicator with ETA for benchmark phases."""
+    """Simple console progress indicator with ETA for benchmark phases.
 
-    def __init__(self, total_steps: int, *, enabled: bool = False, stream: Optional[IO[str]] = None) -> None:
-        self.total_steps = max(0, total_steps)
+    Uses a weighted-progress model: each phase contributes progress
+    proportional to its estimated work (token-processing cost) rather
+    than counting every phase as an equal unit. ETA is refined
+    adaptively using actual elapsed time from completed phases.
+    """
+
+    def __init__(
+        self,
+        total_weight: float = 0.0,
+        *,
+        enabled: bool = False,
+        stream: Optional[IO[str]] = None,
+        prompt_cost: float = DEFAULT_PROMPT_COST,
+        gen_cost: float = DEFAULT_GEN_COST,
+    ) -> None:
+        self.total_weight = max(0.0, total_weight)
         self.enabled = enabled
         self.stream = stream or sys.stdout
+        self.prompt_cost = prompt_cost
+        self.gen_cost = gen_cost
         self._started_at: Optional[float] = None
+        self._completed_weight: float = 0.0
+        self._phase_weights: List[float] = []
+        self._phase_elapsed: List[float] = []
+        self._current_phase_start: Optional[float] = None
 
     def start(self) -> None:
         if not self.enabled:
             return
         self._started_at = time.perf_counter()
 
-    def render(self, current_step: int, *, description: str = "", total_steps: Optional[int] = None, elapsed: Optional[float] = None) -> None:
+    def add_phase(self, weight: float) -> None:
+        """Register a phase with its estimated work weight.
+
+        Called before the benchmark starts to pre-register all phases,
+        or incrementally as phases are discovered. The total weight is
+        updated accordingly.
+        """
+        if not self.enabled:
+            return
+        self._phase_weights.append(max(0.0, weight))
+        self.total_weight = sum(self._phase_weights)
+
+    def render(
+        self,
+        completed_weight: float,
+        *,
+        description: str = "",
+        total_weight: Optional[float] = None,
+        elapsed: Optional[float] = None,
+        current_phase_weight: float = 0.0,
+    ) -> None:
+        """Render the progress bar.
+
+        Args:
+            completed_weight: Cumulative weight of **fully completed** phases.
+                This is used for ETA calculation (only completed work counts).
+            description: Human-readable description of the current phase.
+            total_weight: Override total weight (defaults to self.total_weight).
+            elapsed: Override elapsed time (for testing).
+            current_phase_weight: Weight of the current in-progress phase,
+                added to the display for visual progress but NOT included
+                in ETA calculation.
+        """
         if not self.enabled:
             return
 
-        total = self.total_steps if total_steps is None else max(0, total_steps)
+        total = self.total_weight if total_weight is None else max(0.0, total_weight)
         if total <= 0:
             return
 
-        current = max(0, min(current_step, total))
+        # For display: include current phase weight
+        display_completed = max(0.0, min(completed_weight + current_phase_weight, total))
+        # For ETA: only use actually completed weight
+        eta_completed = max(0.0, min(completed_weight, total))
+
         if self._started_at is None:
             self._started_at = time.perf_counter()
 
         elapsed = time.perf_counter() - self._started_at if elapsed is None else elapsed
-        completed = max(0, current)
-        percent = (completed / total) * 100 if total else 0
+        percent = (display_completed / total) * 100 if total else 0
         filled_width = 24
-        filled = int((completed / total) * filled_width) if total else 0
-        bar = "[" + "=" * filled + (">" if completed < total and filled < filled_width else "") + "-" * max(0, filled_width - filled - (1 if completed < total and filled < filled_width else 0)) + "]"
+        filled = int((display_completed / total) * filled_width) if total else 0
+        bar = "[" + "=" * filled + (">" if display_completed < total and filled < filled_width else "") + "-" * max(0, filled_width - filled - (1 if display_completed < total and filled < filled_width else 0)) + "]"
 
-        if completed > 0 and elapsed > 0:
-            eta_seconds = elapsed * (total - completed) / completed
-            eta_text = self._format_duration(eta_seconds)
-        else:
-            eta_text = "--:--"
+        eta_text = self._compute_eta(eta_completed, total, elapsed)
 
-        message = f"{bar} {completed}/{total} {description} | {percent:3.0f}% | ETA {eta_text}".rstrip()
+        message = f"{bar} {display_completed:.1f}/{total:.1f} {description} | {percent:3.0f}% | ETA {eta_text}".rstrip()
         self.stream.write("\r\033[K")
         self.stream.write(message)
         self.stream.flush()
+
+    def _compute_eta(self, completed: float, total: float, elapsed: float) -> str:
+        """Compute ETA using a hybrid approach.
+
+        - If we have actual per-phase timings, use the average weight-per-second
+          rate from completed phases to estimate remaining time.
+        - Otherwise, fall back to a simple linear extrapolation based on
+          elapsed time and completed weight fraction.
+
+        The first measured phase is excluded from the rate calculation to
+        avoid first-request overhead (connection pooling, server-side warmup)
+        skewing the estimate.
+        """
+        if completed <= 0 or elapsed <= 0:
+            return "--:--"
+
+        remaining = total - completed
+        if remaining <= 0:
+            return "00:00"
+
+        # Adaptive ETA: use actual measured rate from completed phases
+        # Skip the first measured phase to avoid first-request overhead skewing
+        if len(self._phase_elapsed) >= 2 and sum(self._phase_elapsed[1:]) > 0:
+            total_phase_weight = sum(self._phase_weights[1:len(self._phase_elapsed)])
+            if total_phase_weight > 0:
+                measured_rate = total_phase_weight / sum(self._phase_elapsed[1:])
+                eta_seconds = remaining / measured_rate
+                return self._format_duration(eta_seconds)
+
+        # Fallback: linear extrapolation
+        eta_seconds = elapsed * (total - completed) / completed
+        return self._format_duration(eta_seconds)
+
+    def record_phase_elapsed(self, elapsed: float, phase_weight: float = 0.0) -> None:
+        """Record the actual elapsed time and weight for the most recent phase.
+
+        Used for adaptive ETA computation. Both elapsed time and phase weight
+        must be recorded together so the measured rate (weight/time) is accurate.
+        """
+        if not self.enabled:
+            return
+        self._phase_elapsed.append(max(0.0, elapsed))
+        self._phase_weights.append(max(0.0, phase_weight))
 
     def finish(self, message: Optional[str] = None) -> None:
         if not self.enabled:
@@ -85,6 +188,65 @@ class ConsoleProgressBar:
         if hours:
             return f"{hours:02d}:{minutes:02d}:{sec:02d}"
         return f"{minutes:02d}:{sec:02d}"
+
+
+def compute_phase_weight(
+    pp: int,
+    tg: int,
+    depth: int,
+    *,
+    is_context_load: bool = False,
+    is_inference: bool = False,
+    prompt_cost: float = DEFAULT_PROMPT_COST,
+    gen_cost: float = DEFAULT_GEN_COST,
+) -> float:
+    """Compute the estimated work weight for a single benchmark phase.
+
+    The weight is proportional to the estimated wall-clock duration of the
+    phase, based on the number of tokens the server must process and
+    generate.
+
+    Args:
+        pp: Prompt processing token count (user-facing --pp).
+        tg: Token generation count (user-facing --tg).
+        depth: Context depth (previous conversation tokens).
+        is_context_load: True if this is a prefix-cache context-load phase
+            (full context + probe message sent, KV cache warmed).
+        is_inference: True if this is a prefix-cache inference phase
+            (only user prompt sent, context is cached).
+        prompt_cost: Relative cost per prompt-processing token.
+        gen_cost: Relative cost per generation token.
+
+    Returns:
+        A non-negative float representing the estimated work weight.
+
+    Weighting rationale:
+        - Context Load phase: processes (pp + depth) prompt tokens + generates tg tokens.
+          The full context is sent to warm the KV cache.
+        - Inference phase (prefix caching): processes only pp prompt tokens
+          (context is cached) + generates tg tokens.
+        - Standard run (no prefix caching): processes (pp + depth) prompt tokens
+          + generates tg tokens.
+        - Generation cost dominates: gen_cost >> prompt_cost, reflecting that
+          token generation (decode) is typically 10-50x slower per token
+          than prompt processing (prefill) on modern LLM servers.
+        - Concurrency does NOT multiply the weight: concurrent requests
+          execute in parallel via asyncio.gather, so wall-clock duration
+          is approximately the same as a single request (assuming the
+          server can handle the load). The total server work increases,
+          but the user-visible duration does not.
+    """
+    if is_context_load:
+        # Full context + probe message processed, then tg tokens generated
+        prompt_tokens = pp + depth
+    elif is_inference:
+        # Only user prompt processed (context cached), then tg tokens generated
+        prompt_tokens = pp
+    else:
+        # Standard run: pp + depth tokens processed, tg tokens generated
+        prompt_tokens = pp + depth
+
+    return prompt_tokens * prompt_cost + tg * gen_cost
 
 
 class ProgressEmitter:

--- a/src/llama_benchy/runner.py
+++ b/src/llama_benchy/runner.py
@@ -3,7 +3,7 @@ import subprocess
 import time
 import sys
 from datetime import datetime, timezone
-from typing import List
+from typing import List, Optional
 import aiohttp
 
 from ._version import __version__
@@ -11,7 +11,7 @@ from .config import BenchmarkConfig
 from .client import CONTEXT_LOAD_USER_MESSAGE, LLMClient
 from .prompts import PromptGenerator
 from .results import BenchmarkResults, BenchmarkMetadata
-from .progress import ConsoleProgressBar
+from .progress import ConsoleProgressBar, compute_phase_weight
 
 class BenchmarkFailure(Exception):
     pass
@@ -53,19 +53,49 @@ class BenchmarkRunner:
         except Exception:
             pass
 
-    def _estimate_total_steps(self, warmup_runs: int) -> int:
-        total_steps = 0
-        for _depth in self.config.depths:
-            for _pp in self.config.pp_counts:
-                for _tg in self.config.tg_counts:
-                    for _concurrency in self.config.concurrency_levels:
-                        phase_count = 2 if self.config.enable_prefix_caching and _depth > 0 else 1
-                        total_steps += (self.config.num_runs + warmup_runs) * phase_count
-        return total_steps
+    def _estimate_total_weight(self, warmup_runs: int) -> float:
+        """Estimate the total work weight for the entire benchmark suite.
 
-    def _render_progress(self, current_step: int, description: str) -> None:
+        Each phase's weight is proportional to its estimated token-processing
+        cost (prompt tokens * prompt_cost + generation tokens * gen_cost).
+        This accounts for the fact that larger pp/depth/tg configurations
+        take proportionally longer, and generation is typically much slower
+        per token than prompt processing.
+
+        Concurrency does NOT multiply the weight: concurrent requests
+        execute in parallel via asyncio.gather, so wall-clock duration is
+        approximately the same as a single request.
+        """
+        total_weight = 0.0
+        for depth in self.config.depths:
+            for pp in self.config.pp_counts:
+                for tg in self.config.tg_counts:
+                    for _concurrency in self.config.concurrency_levels:
+                        phase_count = 2 if self.config.enable_prefix_caching and depth > 0 else 1
+                        for _ in range(self.config.num_runs + warmup_runs):
+                            if phase_count == 2:
+                                # Context Load phase: full context + probe
+                                total_weight += compute_phase_weight(
+                                    pp, tg, depth, is_context_load=True
+                                )
+                                # Inference phase: only pp tokens (context cached)
+                                total_weight += compute_phase_weight(
+                                    pp, tg, depth, is_inference=True
+                                )
+                            else:
+                                # Standard run: pp + depth tokens
+                                total_weight += compute_phase_weight(
+                                    pp, tg, depth
+                                )
+        return total_weight
+
+    def _render_progress(self, completed_weight: float, description: str, current_phase_weight: float = 0.0) -> None:
         if self.console_progress is not None:
-            self.console_progress.render(current_step, description=description)
+            self.console_progress.render(
+                completed_weight,
+                description=description,
+                current_phase_weight=current_phase_weight,
+            )
 
     async def run_suite(self):
         # Initialize session
@@ -73,6 +103,7 @@ class BenchmarkRunner:
         max_concurrency = max(self.config.concurrency_levels)
         connector = aiohttp.TCPConnector(limit=max_concurrency + 5, force_close=False, keepalive_timeout=600)
         latency = 0.0  # default in case of early interrupt
+        suite_start_time = time.perf_counter()
 
         try:
             async with aiohttp.ClientSession(timeout=timeout, connector=connector, trust_env=True) as session:
@@ -112,21 +143,28 @@ class BenchmarkRunner:
                 warmup_runs = 0 if self.config.no_warmup else self.config.warmup_runs
                 if self.config.progress_bar:
                     self.console_progress = ConsoleProgressBar(
-                        self._estimate_total_steps(warmup_runs),
+                        self._estimate_total_weight(warmup_runs),
                         enabled=True,
                     )
                     self.console_progress.start()
                 else:
                     self.console_progress = None
 
-                step_counter = 0
+                completed_weight = 0.0
+                current_phase_weight = 0.0
+                phase_start_time: Optional[float] = None
 
                 # Main Loop
                 for depth in self.config.depths:
                     for pp in self.config.pp_counts:
                         for tg in self.config.tg_counts:
                             for concurrency in self.config.concurrency_levels:
-                                print(f"Running test: pp={pp}, tg={tg}, depth={depth}, concurrency={concurrency}")
+                                # Ensure progress bar line is cleared before printing
+                                if self.console_progress is not None:
+                                    self.console_progress.stream.write("\n")
+                                    self.console_progress.stream.flush()
+                                ts = datetime.now(timezone.utc).strftime("%H:%M:%S")
+                                print(f"[{ts}] Running test: pp={pp}, tg={tg}, depth={depth}, concurrency={concurrency}")
 
                                 run_std_results = []
                                 run_ctx_results = []
@@ -164,10 +202,14 @@ class BenchmarkRunner:
 
                                     if self.config.enable_prefix_caching and depth > 0:
                                         # Phase 1: Context Load
-                                        step_counter += 1
+                                        phase_start_time = time.perf_counter()
+                                        current_phase_weight = compute_phase_weight(
+                                            current_pp, tg, current_depth, is_context_load=True
+                                        )
                                         self._render_progress(
-                                            step_counter,
+                                            completed_weight,
                                             f"{run_label} (Context Load, batch size {concurrency})",
+                                            current_phase_weight=current_phase_weight,
                                         )
                                         load_tasks = []
                                         for i in range(concurrency):
@@ -187,6 +229,13 @@ class BenchmarkRunner:
                                             ))
 
                                         load_results = await asyncio.gather(*load_tasks)
+                                        if self.console_progress is not None and phase_start_time is not None:
+                                            if not is_warmup:
+                                                self.console_progress.record_phase_elapsed(
+                                                    time.perf_counter() - phase_start_time,
+                                                    phase_weight=current_phase_weight,
+                                                )
+                                            completed_weight += current_phase_weight
                                         if not is_warmup:
                                             run_ctx_results.append(load_results)
 
@@ -196,10 +245,14 @@ class BenchmarkRunner:
                                             raise BenchmarkFailure()
 
                                         # Phase 2: Inference
-                                        step_counter += 1
+                                        phase_start_time = time.perf_counter()
+                                        current_phase_weight = compute_phase_weight(
+                                            current_pp, tg, current_depth, is_inference=True
+                                        )
                                         self._render_progress(
-                                            step_counter,
+                                            completed_weight,
                                             f"{run_label} (Inference, batch size {concurrency})",
+                                            current_phase_weight=current_phase_weight,
                                         )
                                         inf_tasks = []
                                         for i in range(concurrency):
@@ -219,6 +272,13 @@ class BenchmarkRunner:
                                             ))
 
                                         batch_results = await asyncio.gather(*inf_tasks)
+                                        if self.console_progress is not None and phase_start_time is not None:
+                                            if not is_warmup:
+                                                self.console_progress.record_phase_elapsed(
+                                                    time.perf_counter() - phase_start_time,
+                                                    phase_weight=current_phase_weight,
+                                                )
+                                            completed_weight += current_phase_weight
                                         if not is_warmup:
                                             run_std_results.append(batch_results)
 
@@ -229,10 +289,14 @@ class BenchmarkRunner:
 
                                     else:
                                         # Standard Run
-                                        step_counter += 1
+                                        phase_start_time = time.perf_counter()
+                                        current_phase_weight = compute_phase_weight(
+                                            current_pp, tg, current_depth
+                                        )
                                         self._render_progress(
-                                            step_counter,
+                                            completed_weight,
                                             f"{run_label} (batch size {concurrency})",
+                                            current_phase_weight=current_phase_weight,
                                         )
                                         expected_tokens = current_pp + current_depth
                                         batch_tasks = []
@@ -253,6 +317,13 @@ class BenchmarkRunner:
                                             ))
 
                                         batch_results = await asyncio.gather(*batch_tasks)
+                                        if self.console_progress is not None and phase_start_time is not None:
+                                            if not is_warmup:
+                                                self.console_progress.record_phase_elapsed(
+                                                    time.perf_counter() - phase_start_time,
+                                                    phase_weight=current_phase_weight,
+                                                )
+                                            completed_weight += current_phase_weight
                                         if not is_warmup:
                                             run_std_results.append(batch_results)
 
@@ -290,6 +361,10 @@ class BenchmarkRunner:
 
             self.results.save_report(self.config.save_result, self.config.result_format, max(self.config.concurrency_levels) if self.config.concurrency_levels else 1)
 
+            # Print total benchmark time
+            total_elapsed = time.perf_counter() - suite_start_time
+            print(f"\nTotal benchmark time: {ConsoleProgressBar._format_duration(total_elapsed)}")
+
         except (asyncio.CancelledError, KeyboardInterrupt, BenchmarkFailure) as e:
             if self.results.runs:
                 should_save = True
@@ -310,10 +385,19 @@ class BenchmarkRunner:
                             max_concurrency=max_concurrency
                         )
                     self.results.save_report(self.config.save_result, self.config.result_format, max_concurrency)
+
+                    # Print total benchmark time even on interruption
+                    total_elapsed = time.perf_counter() - suite_start_time
+                    print(f"\nTotal benchmark time: {ConsoleProgressBar._format_duration(total_elapsed)}")
             
             if isinstance(e, BenchmarkFailure):
                 sys.exit(1)
             raise
         finally:
             if self.console_progress is not None:
+                # Render 100% completion before finishing
+                self.console_progress.render(
+                    self.console_progress.total_weight,
+                    description="Complete",
+                )
                 self.console_progress.finish()

--- a/src/llama_benchy/runner.py
+++ b/src/llama_benchy/runner.py
@@ -11,6 +11,7 @@ from .config import BenchmarkConfig
 from .client import CONTEXT_LOAD_USER_MESSAGE, LLMClient
 from .prompts import PromptGenerator
 from .results import BenchmarkResults, BenchmarkMetadata
+from .progress import ConsoleProgressBar
 
 class BenchmarkFailure(Exception):
     pass
@@ -22,6 +23,7 @@ class BenchmarkRunner:
         self.prompt_gen = prompt_generator
         self.results = BenchmarkResults()
         self.progress = progress
+        self.console_progress: ConsoleProgressBar | None = None
         self._next_request_id = 0
 
         # We need to track deltas from warmup to adapt prompts
@@ -50,6 +52,20 @@ class BenchmarkRunner:
             )
         except Exception:
             pass
+
+    def _estimate_total_steps(self, warmup_runs: int) -> int:
+        total_steps = 0
+        for _depth in self.config.depths:
+            for _pp in self.config.pp_counts:
+                for _tg in self.config.tg_counts:
+                    for _concurrency in self.config.concurrency_levels:
+                        phase_count = 2 if self.config.enable_prefix_caching and _depth > 0 else 1
+                        total_steps += (self.config.num_runs + warmup_runs) * phase_count
+        return total_steps
+
+    def _render_progress(self, current_step: int, description: str) -> None:
+        if self.console_progress is not None:
+            self.console_progress.render(current_step, description=description)
 
     async def run_suite(self):
         # Initialize session
@@ -92,6 +108,18 @@ class BenchmarkRunner:
                         )
                     except Exception:
                         pass
+
+                warmup_runs = 0 if self.config.no_warmup else self.config.warmup_runs
+                if self.config.progress_bar:
+                    self.console_progress = ConsoleProgressBar(
+                        self._estimate_total_steps(warmup_runs),
+                        enabled=True,
+                    )
+                    self.console_progress.start()
+                else:
+                    self.console_progress = None
+
+                step_counter = 0
 
                 # Main Loop
                 for depth in self.config.depths:
@@ -136,7 +164,11 @@ class BenchmarkRunner:
 
                                     if self.config.enable_prefix_caching and depth > 0:
                                         # Phase 1: Context Load
-                                        print(f"  {run_label} (Context Load, batch size {concurrency})...")
+                                        step_counter += 1
+                                        self._render_progress(
+                                            step_counter,
+                                            f"{run_label} (Context Load, batch size {concurrency})",
+                                        )
                                         load_tasks = []
                                         for i in range(concurrency):
                                             context, _ = prompt_batch[i]
@@ -164,7 +196,11 @@ class BenchmarkRunner:
                                             raise BenchmarkFailure()
 
                                         # Phase 2: Inference
-                                        print(f"  {run_label} (Inference, batch size {concurrency})...")
+                                        step_counter += 1
+                                        self._render_progress(
+                                            step_counter,
+                                            f"{run_label} (Inference, batch size {concurrency})",
+                                        )
                                         inf_tasks = []
                                         for i in range(concurrency):
                                             context, prompt = prompt_batch[i]
@@ -193,7 +229,11 @@ class BenchmarkRunner:
 
                                     else:
                                         # Standard Run
-                                        print(f"  {run_label} (batch size {concurrency})...")
+                                        step_counter += 1
+                                        self._render_progress(
+                                            step_counter,
+                                            f"{run_label} (batch size {concurrency})",
+                                        )
                                         expected_tokens = current_pp + current_depth
                                         batch_tasks = []
                                         for i in range(concurrency):
@@ -274,3 +314,6 @@ class BenchmarkRunner:
             if isinstance(e, BenchmarkFailure):
                 sys.exit(1)
             raise
+        finally:
+            if self.console_progress is not None:
+                self.console_progress.finish()

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,15 +1,28 @@
+import io
 import json
 
 import pytest
 
 from llama_benchy.client import RequestResult
 from llama_benchy.config import BenchmarkConfig
-from llama_benchy.progress import ProgressEmitter, SCHEMA_VERSION
+from llama_benchy.progress import ConsoleProgressBar, ProgressEmitter, SCHEMA_VERSION
 from llama_benchy.runner import BenchmarkRunner
 
 
 def _read_jsonl(path):
     return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def test_console_progress_bar_formats_completion_and_eta():
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_steps=3, enabled=True, stream=stream)
+
+    bar.render(1, description="Context Load", elapsed=2.0)
+
+    output = stream.getvalue()
+    assert "1/3" in output
+    assert "Context Load" in output
+    assert "ETA" in output
 
 
 def test_progress_emitter_writes_estimated_tokens_and_terminal_status(tmp_path):

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -5,7 +5,14 @@ import pytest
 
 from llama_benchy.client import RequestResult
 from llama_benchy.config import BenchmarkConfig
-from llama_benchy.progress import ConsoleProgressBar, ProgressEmitter, SCHEMA_VERSION
+from llama_benchy.progress import (
+    ConsoleProgressBar,
+    ProgressEmitter,
+    SCHEMA_VERSION,
+    compute_phase_weight,
+    DEFAULT_PROMPT_COST,
+    DEFAULT_GEN_COST,
+)
 from llama_benchy.runner import BenchmarkRunner
 
 
@@ -15,14 +22,378 @@ def _read_jsonl(path):
 
 def test_console_progress_bar_formats_completion_and_eta():
     stream = io.StringIO()
-    bar = ConsoleProgressBar(total_steps=3, enabled=True, stream=stream)
+    bar = ConsoleProgressBar(total_weight=3.0, enabled=True, stream=stream)
 
-    bar.render(1, description="Context Load", elapsed=2.0)
+    bar.render(1.0, description="Context Load", elapsed=2.0, current_phase_weight=0.0)
 
     output = stream.getvalue()
-    assert "1/3" in output
+    assert "1.0/3.0" in output
     assert "Context Load" in output
     assert "ETA" in output
+
+
+def test_console_progress_bar_reaches_100_percent():
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=10.0, enabled=True, stream=stream)
+    bar.start()
+
+    bar.render(10.0, description="Complete", elapsed=5.0, current_phase_weight=0.0)
+
+    output = stream.getvalue()
+    assert "100%" in output
+    assert "00:00" in output
+
+
+def test_console_progress_bar_eta_uses_adaptive_rate():
+    """ETA should use actual measured phase timings when available.
+
+    The first measured phase is skipped to avoid first-request overhead.
+    """
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=10.0, enabled=True, stream=stream)
+    bar.start()
+
+    # Record two phases: first (skipped for ETA), second (used for ETA)
+    # Phase 1: 3 weight in 2s (skipped)
+    # Phase 2: 3 weight in 2s (used)
+    bar._phase_weights = [3.0, 3.0]
+    bar._phase_elapsed = [2.0, 2.0]
+
+    # Now render with 6/10 completed — ETA should be based on measured rate
+    # completed_weight=6.0 (actually completed), current_phase_weight=0 (no in-progress phase)
+    bar.render(6.0, description="Phase 2", elapsed=4.0, current_phase_weight=0.0)
+
+    output = stream.getvalue()
+    # Measured rate (excluding first phase): 3.0 weight / 2.0s = 1.5 weight/s
+    # Remaining: 4.0 weight → ETA = 4.0 / 1.5 = 2.67s → "00:02" (truncated)
+    assert "ETA 00:02" in output
+
+
+def test_console_progress_bar_eta_fallback_linear():
+    """Without measured phase timings, ETA falls back to linear extrapolation."""
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=10.0, enabled=True, stream=stream)
+    bar.start()
+
+    # No phases recorded, so linear extrapolation: 5.0/10.0 done in 4.0s
+    # ETA = 4.0 * (10-5)/5 = 4.0s → "00:04"
+    bar.render(5.0, description="Halfway", elapsed=4.0, current_phase_weight=0.0)
+
+    output = stream.getvalue()
+    assert "ETA 00:04" in output
+
+
+def test_console_progress_bar_monotonic():
+    """Progress percentage should never decrease."""
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=100.0, enabled=True, stream=stream)
+    bar.start()
+
+    bar.render(10.0, description="Phase 1", elapsed=1.0, current_phase_weight=0.0)
+    bar.render(50.0, description="Phase 2", elapsed=5.0, current_phase_weight=0.0)
+    bar.render(30.0, description="Phase 3", elapsed=6.0, current_phase_weight=0.0)  # Should be clamped to 50%
+
+    output = stream.getvalue()
+    # The last render should show 50% (clamped), not 30%
+    assert "50%" in output
+
+
+def test_compute_phase_weight_standard_run():
+    """Standard run weight = (pp + depth) * prompt_cost + tg * gen_cost."""
+    weight = compute_phase_weight(pp=2048, tg=32, depth=0)
+    expected = (2048 + 0) * DEFAULT_PROMPT_COST + 32 * DEFAULT_GEN_COST
+    assert weight == expected
+
+
+def test_compute_phase_weight_with_depth():
+    """Standard run with depth includes depth in prompt tokens."""
+    weight = compute_phase_weight(pp=2048, tg=32, depth=4096)
+    expected = (2048 + 4096) * DEFAULT_PROMPT_COST + 32 * DEFAULT_GEN_COST
+    assert weight == expected
+
+
+def test_compute_phase_weight_context_load():
+    """Context load phase processes full context (pp + depth)."""
+    weight = compute_phase_weight(pp=2048, tg=32, depth=4096, is_context_load=True)
+    expected = (2048 + 4096) * DEFAULT_PROMPT_COST + 32 * DEFAULT_GEN_COST
+    assert weight == expected
+
+
+def test_compute_phase_weight_inference():
+    """Inference phase (prefix caching) processes only pp (context cached)."""
+    weight = compute_phase_weight(pp=2048, tg=32, depth=4096, is_inference=True)
+    expected = 2048 * DEFAULT_PROMPT_COST + 32 * DEFAULT_GEN_COST
+    assert weight == expected
+
+
+def test_compute_phase_weight_context_load_heavier_than_inference():
+    """Context load should be heavier than inference when depth > 0."""
+    ctx_weight = compute_phase_weight(pp=2048, tg=32, depth=4096, is_context_load=True)
+    inf_weight = compute_phase_weight(pp=2048, tg=32, depth=4096, is_inference=True)
+    assert ctx_weight > inf_weight
+
+
+def test_compute_phase_weight_larger_pp_is_heavier():
+    """Larger pp should produce larger weight."""
+    small = compute_phase_weight(pp=2048, tg=32, depth=0)
+    large = compute_phase_weight(pp=128000, tg=32, depth=0)
+    assert large > small
+    # 128000/2048 = 62.5x more prompt tokens
+    assert large > small * 10
+
+
+def test_compute_phase_weight_larger_tg_is_heavier():
+    """Larger tg should produce larger weight."""
+    small = compute_phase_weight(pp=2048, tg=32, depth=0)
+    large = compute_phase_weight(pp=2048, tg=256, depth=0)
+    assert large > small
+    # 256/32 = 8x more gen tokens, and gen_cost >> prompt_cost
+    assert large > small * 2
+
+
+def test_compute_phase_weight_larger_depth_is_heavier():
+    """Larger depth should produce larger weight in standard runs."""
+    small = compute_phase_weight(pp=2048, tg=32, depth=0)
+    large = compute_phase_weight(pp=2048, tg=32, depth=4096)
+    assert large > small
+
+
+def test_compute_phase_weight_concurrency_does_not_affect():
+    """Concurrency should NOT affect the weight (parallel execution)."""
+    weight_c1 = compute_phase_weight(pp=2048, tg=32, depth=0)
+    weight_c8 = compute_phase_weight(pp=2048, tg=32, depth=0)
+    assert weight_c1 == weight_c8
+
+
+def test_compute_phase_weight_custom_costs():
+    """Custom cost factors should be respected."""
+    weight = compute_phase_weight(
+        pp=100, tg=10, depth=50,
+        prompt_cost=2.0, gen_cost=5.0,
+    )
+    expected = (100 + 50) * 2.0 + 10 * 5.0
+    assert weight == expected
+
+
+def test_compute_phase_weight_zero_tokens():
+    """Zero tokens should produce zero weight."""
+    weight = compute_phase_weight(pp=0, tg=0, depth=0)
+    assert weight == 0.0
+
+
+def test_compute_phase_weight_negative_clamped():
+    """Negative token counts should be handled gracefully."""
+    weight = compute_phase_weight(pp=-100, tg=32, depth=0)
+    # pp is clamped to 0 in the formula via max(0, ...)
+    # Actually, the formula doesn't clamp — but negative pp would give negative weight
+    # Let's verify the behavior is at least non-crashing
+    assert isinstance(weight, float)
+
+
+def test_progress_bar_disabled_is_noop():
+    """Disabled progress bar should not write anything."""
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=10.0, enabled=False, stream=stream)
+    bar.start()
+    bar.render(5.0, description="Test")
+    bar.finish()
+    assert stream.getvalue() == ""
+
+
+def test_progress_bar_add_phase_accumulates():
+    """add_phase should accumulate total weight."""
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=0.0, enabled=True, stream=stream)
+    bar.start()
+
+    bar.add_phase(3.0)
+    assert bar.total_weight == 3.0
+
+    bar.add_phase(7.0)
+    assert bar.total_weight == 10.0
+
+
+def test_progress_bar_record_phase_elapsed():
+    """record_phase_elapsed should store elapsed times and weights for adaptive ETA."""
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=10.0, enabled=True, stream=stream)
+    bar.start()
+
+    bar.record_phase_elapsed(2.0, phase_weight=5.0)
+
+    assert bar._phase_elapsed == [2.0]
+    assert bar._phase_weights == [5.0]
+
+
+def test_progress_bar_eta_with_multiple_phases():
+    """ETA should use average rate across multiple completed phases.
+
+    The first measured phase is skipped to avoid first-request overhead.
+    """
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=100.0, enabled=True, stream=stream)
+    bar.start()
+
+    # Phase 1: 10 weight in 2s → 5 weight/s (skipped for ETA)
+    # Phase 2: 20 weight in 4s → 5 weight/s (used for ETA)
+    bar._phase_weights = [10.0, 20.0]
+    bar._phase_elapsed = [2.0, 4.0]
+
+    # Total completed: 30 weight in 6s
+    # Measured rate (excluding first phase): 20 / 4 = 5 weight/s
+    # Remaining: 70 weight → ETA = 70/5 = 14s → "00:14"
+    bar.render(30.0, description="Phase 2", elapsed=6.0, current_phase_weight=0.0)
+
+    output = stream.getvalue()
+    assert "ETA 00:14" in output
+
+
+def test_progress_bar_eta_zero_remaining():
+    """ETA should show 00:00 when all work is done."""
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=10.0, enabled=True, stream=stream)
+    bar.start()
+
+    bar.render(10.0, description="Complete", elapsed=5.0, current_phase_weight=0.0)
+
+    output = stream.getvalue()
+    assert "00:00" in output
+
+
+def test_progress_bar_eta_no_completed_work():
+    """ETA should show --:-- when no work is completed."""
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=10.0, enabled=True, stream=stream)
+    bar.start()
+
+    bar.render(0.0, description="Starting", elapsed=0.0, current_phase_weight=0.0)
+
+    output = stream.getvalue()
+    assert "--:--" in output
+
+
+def test_progress_bar_format_duration_hours():
+    """Duration formatting should handle hours."""
+    assert ConsoleProgressBar._format_duration(3661) == "01:01:01"
+    assert ConsoleProgressBar._format_duration(3600) == "01:00:00"
+    assert ConsoleProgressBar._format_duration(7325) == "02:02:05"
+
+
+def test_progress_bar_format_duration_minutes():
+    """Duration formatting should handle minutes."""
+    assert ConsoleProgressBar._format_duration(65) == "01:05"
+    assert ConsoleProgressBar._format_duration(125) == "02:05"
+    assert ConsoleProgressBar._format_duration(0) == "00:00"
+
+
+def test_progress_bar_format_duration_negative():
+    """Negative durations should be clamped to 00:00."""
+    assert ConsoleProgressBar._format_duration(-5) == "00:00"
+
+
+def test_progress_bar_finish_with_message():
+    """finish() with a message should write the message."""
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=10.0, enabled=True, stream=stream)
+    bar.start()
+    bar.finish("Done!")
+    assert "Done!" in stream.getvalue()
+
+
+def test_progress_bar_finish_without_message():
+    """finish() without a message should just clear the line."""
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=10.0, enabled=True, stream=stream)
+    bar.start()
+    bar.finish()
+    assert "\n" in stream.getvalue()
+
+
+def test_progress_bar_total_weight_zero():
+    """Progress bar with zero total weight should not render."""
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=0.0, enabled=True, stream=stream)
+    bar.start()
+    bar.render(0.0, description="Test", current_phase_weight=0.0)
+    assert stream.getvalue() == ""
+
+
+def test_progress_bar_clamps_completed_to_total():
+    """Completed weight exceeding total should be clamped."""
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=10.0, enabled=True, stream=stream)
+    bar.start()
+
+    bar.render(15.0, description="Over", elapsed=5.0, current_phase_weight=0.0)
+
+    output = stream.getvalue()
+    assert "100%" in output
+
+
+def test_progress_bar_eta_during_warmup():
+    """During warmup (no completed phases), ETA should use linear fallback.
+
+    The completed_weight is 0 (no phases finished), but current_phase_weight
+    shows the in-progress phase. ETA should be based on linear extrapolation
+    from elapsed time, not from the current phase's weight.
+    """
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=100.0, enabled=True, stream=stream)
+    bar.start()
+
+    # First phase starting: 0 completed, 10 in-progress, 1s elapsed
+    bar.render(0.0, description="Warmup 1/2", elapsed=1.0, current_phase_weight=10.0)
+
+    output = stream.getvalue()
+    # Linear fallback: completed=0, so ETA is "--:--"
+    assert "--:--" in output
+    # Display should show 10/100 (current phase weight included)
+    assert "10.0/100.0" in output
+
+
+def test_progress_bar_eta_after_first_phase():
+    """After first phase completes, ETA should use linear fallback (first phase skipped).
+
+    The first measured phase is skipped for adaptive ETA, so with only 1
+    phase recorded, we fall back to linear extrapolation.
+    """
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=100.0, enabled=True, stream=stream)
+    bar.start()
+
+    # First phase completed: 10 weight in 2s (will be skipped for adaptive ETA)
+    bar._phase_weights = [10.0]
+    bar._phase_elapsed = [2.0]
+
+    # Second phase starting: 10 completed, 20 in-progress, 3s elapsed
+    bar.render(10.0, description="Phase 2", elapsed=3.0, current_phase_weight=20.0)
+
+    output = stream.getvalue()
+    # Only 1 phase recorded, so adaptive ETA is skipped (needs >= 2)
+    # Linear fallback: eta = 3.0 * (100 - 10) / 10 = 27s → "00:27"
+    assert "ETA 00:27" in output
+    # Display should show 30/100 (10 completed + 20 in-progress)
+    assert "30.0/100.0" in output
+
+
+def test_progress_bar_eta_skips_first_phase():
+    """First measured phase should be skipped for adaptive ETA calculation."""
+    stream = io.StringIO()
+    bar = ConsoleProgressBar(total_weight=100.0, enabled=True, stream=stream)
+    bar.start()
+
+    # Phase 1: 10 weight in 10s (slow due to first-request overhead, skipped)
+    # Phase 2: 10 weight in 2s (normal speed, used for ETA)
+    bar._phase_weights = [10.0, 10.0]
+    bar._phase_elapsed = [10.0, 2.0]
+
+    # 20 completed, 0 in-progress, 12s elapsed
+    bar.render(20.0, description="Phase 3", elapsed=12.0, current_phase_weight=0.0)
+
+    output = stream.getvalue()
+    # Adaptive ETA (excluding first phase): rate = 10/2 = 5 weight/s
+    # Remaining: 80 weight → ETA = 80/5 = 16s → "00:16"
+    assert "ETA 00:16" in output
 
 
 def test_progress_emitter_writes_estimated_tokens_and_terminal_status(tmp_path):
@@ -192,3 +563,239 @@ async def test_warmup_runs_preserve_progress_streaming_contract(tmp_path):
             "tokens",
             "request_end",
         ]
+
+
+# --- Runner-level weighted progress tests ---
+
+
+def _make_config(**overrides):
+    """Create a BenchmarkConfig with sensible defaults for progress tests."""
+    defaults = dict(
+        base_url="http://example.test/v1",
+        api_key="EMPTY",
+        model="model",
+        served_model_name="model",
+        tokenizer=None,
+        pp_counts=[2048],
+        tg_counts=[32],
+        exact_tg=False,
+        depths=[0],
+        num_runs=1,
+        warmup_runs=0,
+        no_cache=False,
+        latency_mode="none",
+        no_warmup=True,
+        skip_coherence=True,
+        adapt_prompt=False,
+        enable_prefix_caching=False,
+        book_url="",
+        post_run_cmd=None,
+        concurrency_levels=[1],
+        save_result=None,
+        result_format="md",
+        save_total_throughput_timeseries=False,
+        save_all_throughput_timeseries=False,
+        exit_on_first_fail=False,
+        no_results_on_fail=False,
+        extra_body={},
+        emit_progress=None,
+        progress_bar=False,
+    )
+    defaults.update(overrides)
+    return BenchmarkConfig(**defaults)
+
+
+def test_estimate_total_weight_standard_run():
+    """Total weight for a single standard run should match compute_phase_weight."""
+    config = _make_config(pp_counts=[2048], tg_counts=[32], depths=[0], num_runs=1, warmup_runs=0)
+    runner = BenchmarkRunner(config, _FakeBenchmarkClient(), _FakePromptGenerator())
+
+    weight = runner._estimate_total_weight(warmup_runs=0)
+    expected = compute_phase_weight(pp=2048, tg=32, depth=0)
+    assert weight == expected
+
+
+def test_estimate_total_weight_multiple_runs():
+    """Total weight should scale with num_runs."""
+    config = _make_config(pp_counts=[2048], tg_counts=[32], depths=[0], num_runs=3, warmup_runs=0)
+    runner = BenchmarkRunner(config, _FakeBenchmarkClient(), _FakePromptGenerator())
+
+    weight = runner._estimate_total_weight(warmup_runs=0)
+    single = compute_phase_weight(pp=2048, tg=32, depth=0)
+    assert weight == single * 3
+
+
+def test_estimate_total_weight_includes_warmup():
+    """Total weight should include warmup runs."""
+    config = _make_config(pp_counts=[2048], tg_counts=[32], depths=[0], num_runs=1, warmup_runs=2)
+    runner = BenchmarkRunner(config, _FakeBenchmarkClient(), _FakePromptGenerator())
+
+    weight = runner._estimate_total_weight(warmup_runs=2)
+    single = compute_phase_weight(pp=2048, tg=32, depth=0)
+    assert weight == single * 3  # 1 measured + 2 warmup
+
+
+def test_estimate_total_weight_prefix_caching():
+    """With prefix caching and depth > 0, each run has 2 phases (context load + inference)."""
+    config = _make_config(
+        pp_counts=[2048], tg_counts=[32], depths=[4096],
+        num_runs=1, warmup_runs=0, enable_prefix_caching=True,
+    )
+    runner = BenchmarkRunner(config, _FakeBenchmarkClient(), _FakePromptGenerator())
+
+    weight = runner._estimate_total_weight(warmup_runs=0)
+    ctx_weight = compute_phase_weight(pp=2048, tg=32, depth=4096, is_context_load=True)
+    inf_weight = compute_phase_weight(pp=2048, tg=32, depth=4096, is_inference=True)
+    assert weight == ctx_weight + inf_weight
+
+
+def test_estimate_total_weight_larger_pp_is_heavier():
+    """Larger pp configurations should produce larger total weight."""
+    config_small = _make_config(pp_counts=[2048], tg_counts=[32], depths=[0])
+    config_large = _make_config(pp_counts=[128000], tg_counts=[32], depths=[0])
+
+    runner_small = BenchmarkRunner(config_small, _FakeBenchmarkClient(), _FakePromptGenerator())
+    runner_large = BenchmarkRunner(config_large, _FakeBenchmarkClient(), _FakePromptGenerator())
+
+    weight_small = runner_small._estimate_total_weight(warmup_runs=0)
+    weight_large = runner_large._estimate_total_weight(warmup_runs=0)
+
+    assert weight_large > weight_small
+    # 128000/2048 = 62.5x more prompt tokens
+    assert weight_large > weight_small * 10
+
+
+def test_estimate_total_weight_larger_tg_is_heavier():
+    """Larger tg configurations should produce larger total weight."""
+    config_small = _make_config(pp_counts=[2048], tg_counts=[32], depths=[0])
+    config_large = _make_config(pp_counts=[2048], tg_counts=[256], depths=[0])
+
+    runner_small = BenchmarkRunner(config_small, _FakeBenchmarkClient(), _FakePromptGenerator())
+    runner_large = BenchmarkRunner(config_large, _FakeBenchmarkClient(), _FakePromptGenerator())
+
+    weight_small = runner_small._estimate_total_weight(warmup_runs=0)
+    weight_large = runner_large._estimate_total_weight(warmup_runs=0)
+
+    assert weight_large > weight_small
+
+
+def test_estimate_total_weight_larger_depth_is_heavier():
+    """Larger depth configurations should produce larger total weight."""
+    config_small = _make_config(pp_counts=[2048], tg_counts=[32], depths=[0])
+    config_large = _make_config(pp_counts=[2048], tg_counts=[32], depths=[4096])
+
+    runner_small = BenchmarkRunner(config_small, _FakeBenchmarkClient(), _FakePromptGenerator())
+    runner_large = BenchmarkRunner(config_large, _FakeBenchmarkClient(), _FakePromptGenerator())
+
+    weight_small = runner_small._estimate_total_weight(warmup_runs=0)
+    weight_large = runner_large._estimate_total_weight(warmup_runs=0)
+
+    assert weight_large > weight_small
+
+
+def test_estimate_total_weight_concurrency_does_not_affect():
+    """Concurrency should NOT affect total weight (parallel execution)."""
+    config_c1 = _make_config(pp_counts=[2048], tg_counts=[32], depths=[0], concurrency_levels=[1])
+    config_c8 = _make_config(pp_counts=[2048], tg_counts=[32], depths=[0], concurrency_levels=[8])
+
+    runner_c1 = BenchmarkRunner(config_c1, _FakeBenchmarkClient(), _FakePromptGenerator())
+    runner_c8 = BenchmarkRunner(config_c8, _FakeBenchmarkClient(), _FakePromptGenerator())
+
+    weight_c1 = runner_c1._estimate_total_weight(warmup_runs=0)
+    weight_c8 = runner_c8._estimate_total_weight(warmup_runs=0)
+
+    assert weight_c1 == weight_c8
+
+
+def test_estimate_total_weight_multiple_configurations():
+    """Total weight should be the sum of all configuration combinations."""
+    config = _make_config(
+        pp_counts=[2048, 4096],
+        tg_counts=[32, 64],
+        depths=[0],
+        num_runs=1,
+        warmup_runs=0,
+        concurrency_levels=[1, 2],
+    )
+    runner = BenchmarkRunner(config, _FakeBenchmarkClient(), _FakePromptGenerator())
+
+    weight = runner._estimate_total_weight(warmup_runs=0)
+
+    # 2 pp × 2 tg × 1 depth × 2 concurrency × 1 run = 8 phases
+    # But concurrency doesn't affect weight, so each (pp, tg, depth) combo
+    # is counted once per concurrency level (2x), giving 8 phases total.
+    # Since weight is the same regardless of concurrency, the total is:
+    # 2 (pp) × 2 (tg) × 1 (depth) × 2 (concurrency) × 1 (run) = 8 phases
+    # But each phase has the same weight regardless of concurrency, so:
+    expected = (
+        compute_phase_weight(pp=2048, tg=32, depth=0)
+        + compute_phase_weight(pp=2048, tg=64, depth=0)
+        + compute_phase_weight(pp=4096, tg=32, depth=0)
+        + compute_phase_weight(pp=4096, tg=64, depth=0)
+    ) * 2  # ×2 for two concurrency levels
+    assert weight == expected
+
+
+def test_estimate_total_weight_prefix_caching_context_load_heavier():
+    """Context load phase should be heavier than inference phase when depth > 0."""
+    config = _make_config(
+        pp_counts=[2048], tg_counts=[32], depths=[4096],
+        num_runs=1, warmup_runs=0, enable_prefix_caching=True,
+    )
+    runner = BenchmarkRunner(config, _FakeBenchmarkClient(), _FakePromptGenerator())
+
+    weight = runner._estimate_total_weight(warmup_runs=0)
+
+    ctx_weight = compute_phase_weight(pp=2048, tg=32, depth=4096, is_context_load=True)
+    inf_weight = compute_phase_weight(pp=2048, tg=32, depth=4096, is_inference=True)
+
+    # Total should be ctx + inf, and ctx should be > inf
+    assert weight == ctx_weight + inf_weight
+    assert ctx_weight > inf_weight
+
+
+def test_estimate_total_weight_no_warmup():
+    """With no_warmup, warmup_runs should be 0."""
+    config = _make_config(
+        pp_counts=[2048], tg_counts=[32], depths=[0],
+        num_runs=1, warmup_runs=2, no_warmup=True,
+    )
+    runner = BenchmarkRunner(config, _FakeBenchmarkClient(), _FakePromptGenerator())
+
+    # no_warmup means warmup_runs is treated as 0
+    weight = runner._estimate_total_weight(warmup_runs=0)
+    single = compute_phase_weight(pp=2048, tg=32, depth=0)
+    assert weight == single
+
+
+@pytest.mark.asyncio
+async def test_warmup_phases_excluded_from_eta(tmp_path):
+    """Warmup phases should not contribute to adaptive ETA calculation.
+
+    Warmup phases include model loading and connection setup overhead,
+    which would skew the measured rate if included. Only non-warmup
+    (measured) phases should be recorded for ETA.
+    """
+    result_path = tmp_path / "results.json"
+    config = _make_config(
+        pp_counts=[4],
+        tg_counts=[2],
+        depths=[0],
+        num_runs=1,
+        warmup_runs=1,
+        no_warmup=False,
+        skip_coherence=True,
+        latency_mode="none",
+        progress_bar=True,
+        save_result=str(result_path),
+    )
+    client = _FakeBenchmarkClient()
+    runner = BenchmarkRunner(config, client, _FakePromptGenerator())
+
+    await runner.run_suite()
+
+    # The console_progress should have recorded only 1 phase (the measured run,
+    # not the warmup run)
+    assert runner.console_progress is not None
+    assert len(runner.console_progress._phase_elapsed) == 1
+    assert len(runner.console_progress._phase_weights) == 1  # phase weight recorded with elapsed


### PR DESCRIPTION
#6 
# Added an opt-in console progress bar for benchmark runs

## Summary

This PR adds an opt-in console progress bar for long-running benchmark suites so users can see overall progress, percentage completion, and estimated time remaining while the run is in progress.

## What changed

- Added a new `--progress-bar` CLI flag to enable a live console progress display.
- Updated the benchmark runner to report progress across benchmark phases instead of only printing raw phase messages.
- Added regression coverage for the new progress bar behavior.

## Why

Benchmark runs can produce a lot of console output, making it hard to understand how much work remains or how long the run might take. This makes the experience more informative and less noisy.

## Testing

Verified with:

```bash
pytest -q tests/test_progress.py
```