### PR TITLE
Clarify --no-warmup behavior when --adapt-prompt is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Generally you don't need to disable prompt caching on the server, as a probabili
 -   `--post-run-cmd`: Command to execute after each test run.
 -   `--book-url`: URL of a book to use for text generation (Defaults to Sherlock Holmes).
 -   `--latency-mode`: Method to measure latency: 'api' (call list models function) - default, 'generation' (single token generation), or 'none' (skip latency measurement).
--   `--no-warmup`: Skip warmup phase.
+-   `--no-warmup`: Skip warmup phase. Note: since `--adapt-prompt` is enabled by default and relies on warmup to measure the token delta, warmup will still run unless you also pass `--no-adapt-prompt`.
 -   `--skip-coherence`: Skip coherence test after warmup.
 -   `--adapt-prompt`: Adapt prompt size based on warmup token usage delta (Default: True).
 -   `--no-adapt-prompt`: Disable prompt size adaptation.

--- a/src/llama_benchy/runner.py
+++ b/src/llama_benchy/runner.py
@@ -63,6 +63,12 @@ class BenchmarkRunner:
                 # Warmup
                 should_warmup = not self.config.no_warmup
                 if self.config.adapt_prompt:
+                    if self.config.no_warmup:
+                        print(
+                            "\n[Warning] --no-warmup was specified, but warmup will still run because "
+                            "--adapt-prompt needs it to measure the token delta; pass --no-adapt-prompt "
+                            "as well to skip warmup entirely."
+                        )
                     should_warmup = True
 
                 tokenizer = self.prompt_gen.corpus.get_tokenizer()


### PR DESCRIPTION
Fixes #10

## Root cause
`--no-warmup` appeared to be silently ignored. In `run_suite()`, the
warmup-skip flag was unconditionally overridden whenever `adapt_prompt`
was true (the default):

    should_warmup = not self.config.no_warmup
    if self.config.adapt_prompt:
        should_warmup = True

Warmup genuinely has to run in that case — `--adapt-prompt` measures the
token delta during warmup and needs it — but nothing told the user why,
so `--no-warmup` looked broken.

## Fix
This is a UX/clarity fix only, not a behavior change. When `--no-warmup`
is passed but `adapt_prompt` is still true, we now print a one-line
warning explaining that warmup will still run because `--adapt-prompt`
needs it, and that `--no-adapt-prompt` should also be passed to skip
warmup entirely. The actual control flow is untouched.

Also updated the `--no-warmup` bullet in README.md to document this
interaction.

## Test plan
- `uv sync --all-extras --dev && uv run pytest tests/test_mock_integration.py`
  — note: in my sandbox both tests fail before and after this change due
  to the environment's network policy blocking the `gpt2` tokenizer
  download from huggingface.co (unrelated pre-existing issue, verified
  via `git stash`).
