### PR TITLE
Fail closed when tokenizer assets do not load

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ As of January 2nd, 2026, I wasn't able to find any existing benchmarking tool th
 - Reports Time To First Response (data chunk) (TTFR), Estimated Prompt Processing Time (est_ppt), and End-to-End TTFT.
 - Supports configurable prompt length (`--pp`), generation length (`--tg`), and context depth (`--depth`).
 - Can run multiple iterations (`--runs`) and report mean ± std.
-- Uses HuggingFace tokenizers for accurate token counts.
+- Loads each model's HuggingFace tokenizer assets before model configuration, including architectures newer than the installed Transformers release.
+- Fails when the requested tokenizer cannot load instead of silently substituting an unrelated tokenizer.
 - Correctly handles multi-token prediction (MTP) chunks.
 - Downloads a book from Project Gutenberg to use as source text for prompts to ensure better benchmarking of spec.decoding/MTP models.
 - Supports executing a command after each run (e.g., to clear cache).

--- a/src/llama_benchy/corpus.py
+++ b/src/llama_benchy/corpus.py
@@ -57,16 +57,12 @@ class TokenizedCorpus:
 
         try:
             return self._get_transformers_tokenizer(name)
-        except Exception as e:
-            print(
-                f"Error loading tokenizer '{name}': {e} "
-                f"(lightweight tokenizer error: {lightweight_error})"
-            )
-            print("Falling back to 'gpt2' tokenizer as approximation.")
-            try:
-                return LightweightTokenizer.from_pretrained("gpt2")
-            except Exception:
-                return self._get_transformers_tokenizer("gpt2")
+        except Exception as auto_error:
+            raise RuntimeError(
+                f"Unable to load tokenizer '{name}' from its tokenizer assets "
+                f"or Transformers configuration. Lightweight tokenizer error: "
+                f"{lightweight_error}. AutoTokenizer error: {auto_error}."
+            ) from auto_error
 
     def _load_data(self):
         try:

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,5 +1,11 @@
+import json
 import sys
 import types
+
+import pytest
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from tokenizers.pre_tokenizers import Whitespace
 
 from llama_benchy.corpus import LightweightTokenizer, TokenizedCorpus
 
@@ -58,6 +64,41 @@ def test_lightweight_tokenizer_matches_transformers_encode_decode_shape(monkeypa
     assert raw.decode_calls == [([1, 2, 3], False)]
 
 
+def test_deepseek_v4_uses_local_tokenizer_json_before_transformers(tmp_path, monkeypatch):
+    tokenizer = Tokenizer(WordLevel({"[UNK]": 0, "hello": 1}, unk_token="[UNK]"))
+    tokenizer.pre_tokenizer = Whitespace()
+    tokenizer.save(str(tmp_path / "tokenizer.json"))
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "max_position_embeddings": 4096,
+                "model_type": "deepseek_v4",
+                "rope_scaling": {
+                    "beta_fast": 32,
+                    "beta_slow": 1,
+                    "factor": 2,
+                    "original_max_position_embeddings": 2048,
+                    "type": "yarn",
+                },
+                "rope_theta": 10000,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    corpus = TokenizedCorpus.__new__(TokenizedCorpus)
+    monkeypatch.setattr(
+        corpus,
+        "_get_transformers_tokenizer",
+        lambda name: pytest.fail("DeepSeek tokenizer.json must load without AutoTokenizer"),
+    )
+
+    loaded = corpus._get_tokenizer(str(tmp_path))
+
+    assert isinstance(loaded, LightweightTokenizer)
+    assert loaded.encode("hello", add_special_tokens=False) == [1]
+
+
 def test_get_tokenizer_uses_lightweight_backend_without_transformers(monkeypatch):
     class FakeTokenizer:
         @staticmethod
@@ -109,16 +150,14 @@ def test_get_tokenizer_lazily_uses_transformers_when_lightweight_fails(monkeypat
     ]
 
 
-def test_get_tokenizer_falls_back_to_lightweight_gpt2(monkeypatch):
+def test_get_tokenizer_fails_instead_of_substituting_gpt2(monkeypatch):
     class FakeTokenizer:
         calls = []
 
         @classmethod
         def from_pretrained(cls, name):
             cls.calls.append(name)
-            if name == "repo/model":
-                raise RuntimeError("missing tokenizer.json")
-            return _FakeRawTokenizer()
+            raise RuntimeError("missing tokenizer.json")
 
     class FakeAutoTokenizer:
         calls = []
@@ -132,10 +171,14 @@ def test_get_tokenizer_falls_back_to_lightweight_gpt2(monkeypatch):
     _install_transformers(monkeypatch, FakeAutoTokenizer)
 
     corpus = TokenizedCorpus.__new__(TokenizedCorpus)
-    tokenizer = corpus._get_tokenizer("repo/model")
+    with pytest.raises(
+        RuntimeError,
+        match="Unable to load tokenizer 'repo/model' from its tokenizer assets",
+    ) as error:
+        corpus._get_tokenizer("repo/model")
 
-    assert isinstance(tokenizer, LightweightTokenizer)
-    assert FakeTokenizer.calls == ["repo/model", "gpt2"]
+    assert isinstance(error.value.__cause__, MemoryError)
+    assert FakeTokenizer.calls == ["repo/model"]
     assert FakeAutoTokenizer.calls == [
         (("repo/model",), {"use_fast": True, "trust_remote_code": False})
     ]

--- a/tests/test_mock_integration.py
+++ b/tests/test_mock_integration.py
@@ -65,6 +65,7 @@ async def test_benchy_integration(mock_server_url):
         sys.executable, "-m", "llama_benchy",
         "--base-url", mock_server_url,
         "--model", "test-model",
+        "--tokenizer", "gpt2",
         "--depth", "0", "4096",
         "--format", "json"
     ]
@@ -162,6 +163,7 @@ async def test_mtp_integration(mock_server_url):
         sys.executable, "-m", "llama_benchy",
         "--base-url", mock_server_url,
         "--model", f"test-model-mtp{MTP_FACTOR}",
+        "--tokenizer", "gpt2",
         "--depth", "0",
         "--format", "json"
     ]


### PR DESCRIPTION
## What changed

- Stop substituting GPT-2 when both requested tokenizer loaders fail.
- Raise one error that preserves the lightweight and Transformers failures.
- Cover the DeepSeek V4 tokenizer.json path with its unsupported model type and RoPE configuration.
- Select GPT-2 explicitly for synthetic integration model IDs.

## Why

DeepSeek V4 has valid tokenizer assets even when Transformers does not recognize its model configuration. Those assets load through the lightweight backend. If neither requested tokenizer path works, continuing with GPT-2 produces invalid prompt sizes and benchmark results.

## Validation

`uv run --extra dev pytest -q` passes 26 tests.
