### PR TITLE
docs: document MLX / Apple Silicon usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This script benchmarks OpenAI-compatible LLM endpoints, generating statistics si
 ## Motivation
 
 `llama-bench` is a CLI tool that is a part of a very popular [llama.cpp](https://github.com/ggml-org/llama.cpp) inference engine. It is widely used in LLM community to benchmark models and allows to perform measurement at different context sizes.
-However, it is available only for llama.cpp and cannot be used with other inference engines, like vllm or SGLang.
+However, it is available only for llama.cpp and cannot be used with other inference engines, like vllm, SGLang or MLX.
 
 Also, it performs measurements using the C++ engine directly which is not representative of the end user experience which can be quite different in practice.
 
@@ -295,6 +295,43 @@ llama-benchy \
 ```
 
 This will run benchmarks for all combinations of pp (128, 256), tg (32, 64), and depth (0, 1024).
+
+### MLX on Apple Silicon
+
+`llama-benchy` works unmodified against [`mlx-vlm`](https://github.com/Blaizzy/mlx-vlm)'s
+OpenAI-compatible server, which is the usual way to serve MLX models on Apple
+Silicon. `mlx-lm` also ships a compatible server.
+
+```bash
+# serve (mlx_vlm.server defaults --host to 0.0.0.0; bind loopback explicitly)
+mlx_vlm.server --model ~/models/Qwen3.8-27B-4bit --host 127.0.0.1 --port 8080
+
+llama-benchy \
+  --base-url http://127.0.0.1:8080/v1 \
+  --model ~/models/Qwen3.8-27B-4bit \
+  --pp 2048 --tg 128 --depth 0 8192 --runs 3 \
+  --extra-body '{"chat_template_kwargs":{"enable_thinking":false}}'
+```
+
+Two things are worth knowing when benchmarking MLX:
+
+**Disable thinking explicitly for reasoning models.** Qwen3.x-class chat
+templates default to `enable_thinking: true`, so without the `--extra-body`
+above you are benchmarking reasoning tokens as well as the answer. Those tokens
+are generated before any visible output and are not always reported in
+`completion_tokens`, so the run takes much longer than the token counts explain.
+Measured on an M5 Max, the same 2-token answer took 5.3 s at
+`reasoning_effort: low` and 62.0 s at `xhigh`.
+
+**Token counts fall back to stream usage.** `mlx_vlm.server` does not return
+per-chunk `token_ids`, so `llama-benchy` reports:
+
+```
+No complete token_ids in response, using stream usage token count
+```
+
+This is expected and handled - the totals come from the stream's usage block
+rather than from exact ids.
 
 ### Concurrency measurement
 


### PR DESCRIPTION
## Why

The README is titled *"benchmarking tool for all backends"* and the motivation
section names llama.cpp, vLLM and SGLang. MLX is not mentioned anywhere, yet
`llama-benchy` works against `mlx-vlm`'s OpenAI-compatible server with no code
changes at all. MLX is the standard way to run local models on Apple Silicon,
so this seemed like a gap worth filling rather than a feature request.

Docs only, no code touched. Happy to trim, restructure, or drop this if you'd
rather keep the README engine-agnostic.

## What it adds

A `### MLX on Apple Silicon` section under Usage with the serve + benchmark
commands, plus the two behaviours that surprised me:

**1. Reasoning models need `--extra-body` or you silently benchmark thinking**

Qwen3.x-class chat templates default to `enable_thinking: true`. Without

```
--extra-body '{"chat_template_kwargs":{"enable_thinking":false}}'
```

the run includes reasoning tokens. Those are emitted before any visible output
and are not always counted in `completion_tokens`, so wall time far exceeds
what the reported token counts explain.

Measured on an M5 Max, same question, same 2-token visible answer:

| `reasoning_effort` | Wall time |
|---|---|
| `low` | 5.3 s |
| `xhigh` | 62.0 s |

**2. `token_ids` are absent, so the usage fallback fires**

`mlx_vlm.server` does not return per-chunk `token_ids`, so the existing warning
appears:

```
No complete token_ids in response, using stream usage token count
```

The fallback chain in `client.py` handles this correctly. Documenting it stops
people reporting it as a bug.

Also notes that `mlx_vlm.server` defaults `--host` to `0.0.0.0`, so the example
binds loopback explicitly.

## Evidence

Four full suites run against this setup while writing the section:

| | 4-bit | 8-bit |
|---|---|---|
| pp2048 @ d0 | 765.45 ± 19.11 t/s | 608.55 ± 11.13 t/s |
| tg128 @ d0 | 47.53 ± 4.81 t/s | 30.17 ± 0.69 t/s |
| pp2048 @ d8192 | 713.78 ± 13.64 t/s | 686.30 ± 8.41 t/s |
| tg128 @ d8192 | 35.06 ± 2.18 t/s | 24.12 ± 1.60 t/s |

Qwen3.8-27B, MTP speculative decoding on, reasoning off, GPU idle at 2%,
3 runs each. Coherence test passed on every run.

Nothing here needs to go in the README; including it only to show the section
was written against real runs rather than assumed. The exact command is the one
documented in the diff.

## Verified on

mlx-vlm 0.6.14 / mlx 0.32.0 / mlx-lm 0.31.3, macOS 26.6.1 (25G76),
Apple M5 Max 128 GB.
