### PR TITLE
Add Hugging Face dataset workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Generally you don't need to disable prompt caching on the server, as a probabili
 -   `--no-cache`: Add noise to requests to improve prefix caching avoidance. Also sends `cache-prompt=false` to the server.
 -   `--post-run-cmd`: Command to execute after each test run.
 -   `--book-url`: URL of a book to use for text generation (Defaults to Sherlock Holmes).
+-   `--messages-dataset`: Load agent trajectories from a public Hugging Face dataset using a URL-like selector: `owner/dataset?subset=...&split=...&instance_id=...`. Repeat `instance_id` query parameters for a suite. Selected trajectories are cached locally and no payload is committed with llama-benchy.
 -   `--latency-mode`: Method to measure latency: 'api' (call list models function) - default, 'generation' (single token generation), or 'none' (skip latency measurement).
 -   `--no-warmup`: Skip warmup phase.
 -   `--skip-coherence`: Skip coherence test after warmup.
@@ -194,6 +195,22 @@ llama-benchy \
   --tg 1024 \
   --exact-tg
 ```
+
+For a reproducible public Qwen coding-agent workload, select stable task IDs from NVIDIA Open-SWE-Traces. The OpenHands/Qwen split contains modern system prompts, structured tool calls, tool results, and tasks from different repositories:
+
+```bash
+llama-benchy \
+  --base-url http://localhost:8000/v1 \
+  --model my-model \
+  --messages-dataset 'nvidia/Open-SWE-Traces?subset=openhands&split=qwen35_122b&instance_id=hacker0x01__react-datepicker-4602&instance_id=googleapis__python-api-core-86&instance_id=awslabs__aws-ddk-464&instance_id=vmware__tern-359&instance_id=anchore__grype-2741&instance_id=meltano__sdk-2830' \
+  --tg 1024 \
+  --extra-body temperature=0 \
+  --no-cache
+```
+
+The selector and resolved dataset revision are included in JSON metadata, and each result records its resolved `instance_id@trajectory_id`. Instance selection prefers the longest successful trajectory and uses the trajectory UUID as a deterministic tie-breaker. Open-SWE-Traces is CC BY 4.0 and includes the source repository's SPDX license in each row.
+
+Dataset conversation mode sends each selected trajectory's complete conversation prefix and tool definitions, removing only its completed trailing assistant response. It ignores `--pp`: results use server-observed per-request prompt and completion token counts. `--tg` remains an output cap. Dataset mode requires `--depth 0` and does not support the separate prefix-caching benchmark. Each selected trajectory is a separate benchmark shape. At concurrency `N`, benchy sends `N` copies of that trajectory simultaneously, so the same selected set can be compared directly across concurrency levels.
 
 ### Metrics
 
@@ -225,7 +242,8 @@ The script attempts to estimate network or processing latency to provide "server
     -   Represents the raw time until the client receives *any* stream data from the server (including empty chunks or role definitions, but excluding initial http response header). This includes network latency. The same measurement method is used by `vllm bench serve` to report TTFT.
 
 -   **`est_ppt (ms)` (Estimated Prompt Processing Time)**:
-    -   Calculation: `TTFR - Estimated Latency`.
+    -   Calculation: `End-to-end Time to First Token - Estimated Latency`.
+    -   Uses the first content-bearing token rather than an earlier empty protocol chunk.
     -   Estimated time the server spent processing the prompt. Used for calculating Prompt Processing speed.
 
 -   **`e2e_ttft (ms)` (End-to-End Time To First Token)**:

--- a/schemas/benchmark_report_schema.json
+++ b/schemas/benchmark_report_schema.json
@@ -56,6 +56,19 @@
           "title": "Is Context Prefill Phase",
           "type": "boolean"
         },
+        "prompt_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Resolved public prompt identifier",
+          "title": "Prompt Id"
+        },
         "pp_throughput": {
           "anyOf": [
             {
@@ -258,6 +271,32 @@
       "description": "Maximum concurrency level used in the suite",
       "title": "Max Concurrency",
       "type": "integer"
+    },
+    "prompt_source": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Prompt source type or public dataset ID",
+      "title": "Prompt Source"
+    },
+    "dataset_revision": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Pinned Hugging Face dataset revision",
+      "title": "Dataset Revision"
     },
     "benchmarks": {
       "description": "List of benchmark run results",

--- a/src/llama_benchy/__main__.py
+++ b/src/llama_benchy/__main__.py
@@ -4,11 +4,15 @@ Main entry point for the llama-benchy CLI.
 
 import asyncio
 import datetime
+import requests
 import sys
 from . import __version__
 from .config import BenchmarkConfig
 from .corpus import TokenizedCorpus
-from .prompts import PromptGenerator
+from .prompts import (
+    HuggingFaceConversationPromptGenerator,
+    PromptGenerator,
+)
 from .client import LLMClient
 from .runner import BenchmarkRunner
 from .progress import ProgressEmitter
@@ -30,11 +34,32 @@ async def main_async():
     print(f"Concurrency levels: {config.concurrency_levels}")
 
     # 3. Prepare Data
-    corpus = TokenizedCorpus(config.book_url, config.tokenizer, config.model)
-    print(f"Total tokens available in text corpus: {len(corpus)}")
+    corpus = TokenizedCorpus(
+        config.book_url,
+        config.tokenizer,
+        config.model,
+        load_data=not bool(config.messages_dataset),
+    )
+    if config.messages_dataset:
+        print(f"Loading dataset prompt source: {config.messages_dataset}")
+    else:
+        print(f"Total tokens available in text corpus: {len(corpus)}")
 
     # 4. Initialize Components
-    prompt_gen = PromptGenerator(corpus)
+    prompt_gen: (
+        PromptGenerator | HuggingFaceConversationPromptGenerator
+    )
+    if config.messages_dataset:
+        try:
+            prompt_gen = HuggingFaceConversationPromptGenerator(
+                corpus,
+                config.messages_dataset,
+            )
+        except (OSError, ValueError, requests.RequestException) as e:
+            print(f"Error loading messages dataset: {e}")
+            raise SystemExit(2)
+    else:
+        prompt_gen = PromptGenerator(corpus)
     client = LLMClient(
         config.base_url,
         config.api_key,

--- a/src/llama_benchy/client.py
+++ b/src/llama_benchy/client.py
@@ -28,6 +28,7 @@ class RequestResult:
     first_response_ts: Optional[float] = None
     prompt_tokens: int = 0
     total_tokens: int = 0
+    server_decode_seconds: Optional[float] = None
     error: Optional[str] = None
     token_timestamps: List[float] = field(default_factory=list)
 
@@ -47,7 +48,13 @@ class LLMClient:
         self.exact_tg = exact_tg
         self.headers = {"Authorization": f"Bearer {api_key}"}
 
-    def _build_generation_payload(self, messages: List[Dict[str, str]], max_tokens: int, no_cache: bool) -> Dict[str, Any]:
+    def _build_generation_payload(
+        self,
+        messages: List[Dict[str, Any]],
+        max_tokens: int,
+        no_cache: bool,
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
         payload: Dict[str, Any] = {
             "model": self.model_name,
             "messages": messages,
@@ -56,6 +63,9 @@ class LLMClient:
             "return_token_ids": True,
             "stream_options": {"include_usage": True},
         }
+
+        if tools:
+            payload["tools"] = tools
 
         if no_cache:
             payload["cache_prompt"] = False
@@ -107,6 +117,37 @@ class LLMClient:
 
         step = (last_ts - first_ts) / (token_count - 1)
         return [first_ts + (step * i) for i in range(token_count)]
+
+    @staticmethod
+    def _tool_call_text(tool_calls: Any) -> str:
+        if not isinstance(tool_calls, list):
+            return ""
+        parts = []
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            function = tool_call.get("function")
+            if not isinstance(function, dict):
+                continue
+            name = function.get("name")
+            arguments = function.get("arguments")
+            if isinstance(name, str):
+                parts.append(name)
+            if isinstance(arguments, str):
+                parts.append(arguments)
+        return "".join(parts)
+
+    @staticmethod
+    def _apply_server_decode_timestamps(result: RequestResult) -> None:
+        seconds = result.server_decode_seconds
+        if seconds is None or seconds <= 0 or result.total_tokens <= 0 or result.end_ts <= 0:
+            return
+        step = seconds / result.total_tokens
+        first_ts = result.end_ts - seconds + step
+        result.token_timestamps = [
+            first_ts + step * index for index in range(result.total_tokens)
+        ]
+        result.first_token_ts = first_ts
 
     def _finalize_stream_tokens(
             self,
@@ -311,17 +352,20 @@ class LLMClient:
             tokenizer=None,
             progress=None,
             request_id: Optional[int] = None,
+            messages: Optional[List[Dict[str, Any]]] = None,
+            tools: Optional[List[Dict[str, Any]]] = None,
         ) -> RequestResult:
 
-        messages = []
-        if context_text:
-            messages.append({"role": "system", "content": context_text})
-        messages.append({"role": "user", "content": self._non_empty_user_content(prompt_text)})
+        if messages is None:
+            messages = []
+            if context_text:
+                messages.append({"role": "system", "content": context_text})
+            messages.append({"role": "user", "content": self._non_empty_user_content(prompt_text)})
         
         result = RequestResult()
         
         try:
-            payload = self._build_generation_payload(messages, max_tokens, no_cache)
+            payload = self._build_generation_payload(messages, max_tokens, no_cache, tools)
             
             result.start_ts = time.perf_counter()
 
@@ -365,6 +409,16 @@ class LLMClient:
                                     completion_tokens = usage.get('completion_tokens')
                                     if isinstance(completion_tokens, int) and completion_tokens >= 0:
                                         usage_completion_tokens = completion_tokens
+
+                                timings = chunk.get('timings')
+                                if not isinstance(timings, dict) and isinstance(usage, dict):
+                                    timings = usage.get('timings')
+                                if isinstance(timings, dict):
+                                    decode_ms = timings.get('decode_ms')
+                                    if not isinstance(decode_ms, (int, float)):
+                                        decode_ms = timings.get('predicted_ms')
+                                    if isinstance(decode_ms, (int, float)) and decode_ms > 0:
+                                        result.server_decode_seconds = decode_ms / 1000.0
                                 
                                 if 'choices' in chunk and len(chunk['choices']) > 0:
                                     if result.first_response_ts is None:
@@ -382,8 +436,16 @@ class LLMClient:
                                     content = delta.get('content')
                                     reasoning_content = delta.get('reasoning_content')
                                     reasoning = delta.get('reasoning')
+                                    tool_call_text = self._tool_call_text(delta.get('tool_calls'))
+                                    token_ids = chunk['choices'][0].get('token_ids')
 
-                                    if content or reasoning_content or reasoning:
+                                    if (
+                                        content
+                                        or reasoning_content
+                                        or reasoning
+                                        or tool_call_text
+                                        or (isinstance(token_ids, list) and token_ids)
+                                    ):
                                         if result.first_token_ts is None:
                                             result.first_token_ts = chunk_time
                                             if progress is not None and request_id is not None:
@@ -395,8 +457,7 @@ class LLMClient:
                                                 except Exception:
                                                     pass
 
-                                        token_ids = chunk['choices'][0].get('token_ids')
-                                        text = content or reasoning_content or reasoning
+                                        text = content or reasoning_content or reasoning or tool_call_text
                                         content_chunks.append({
                                             "text": text,
                                             "timestamp": chunk_time,
@@ -421,8 +482,9 @@ class LLMClient:
                             except json.JSONDecodeError:
                                 continue
 
-                self._finalize_stream_tokens(result, content_chunks, usage_completion_tokens, tokenizer)
                 result.end_ts = time.perf_counter()
+                self._finalize_stream_tokens(result, content_chunks, usage_completion_tokens, tokenizer)
+                self._apply_server_decode_timestamps(result)
 
         except Exception as e:
             print(f"Error during run: {e}")

--- a/src/llama_benchy/config.py
+++ b/src/llama_benchy/config.py
@@ -52,6 +52,9 @@ class BenchmarkConfig(BaseModel):
         ..., description="Enable prefix caching performance measurement"
     )
     book_url: str = Field(..., description="URL of a book to use for text generation")
+    messages_dataset: Optional[str] = Field(
+        None, description="Hugging Face agent trajectory dataset used as the prompt source"
+    )
     post_run_cmd: Optional[str] = Field(
         None, description="Command to execute after each test run"
     )
@@ -300,6 +303,16 @@ class BenchmarkConfig(BaseModel):
             help="URL of a book to use for text generation, defaults to Sherlock Holmes",
         )
         parser.add_argument(
+            "--messages-dataset",
+            type=str,
+            default=None,
+            metavar="SELECTOR",
+            help=(
+                "Hugging Face trajectory selector, e.g. "
+                "owner/dataset?subset=default&split=train&instance_id=task-1"
+            ),
+        )
+        parser.add_argument(
             "--latency-mode",
             type=str,
             default="api",
@@ -390,7 +403,8 @@ class BenchmarkConfig(BaseModel):
             args.exit_on_first_fail = True
         if args.warmup_runs < 0:
             parser.error("--warmup-runs must be >= 0")
-
+        if args.messages_dataset and (args.depth != [0] or args.enable_prefix_caching):
+            parser.error("conversation prompts require --depth 0 and cannot use --enable-prefix-caching")
         try:
             extra_body = BenchmarkConfig._parse_extra_body(args.extra_body)
         except ValueError as e:
@@ -426,7 +440,7 @@ class BenchmarkConfig(BaseModel):
             model=model_to_use,
             served_model_name=served_model_name_to_use,
             tokenizer=args.tokenizer,
-            pp_counts=args.pp,
+            pp_counts=[0] if args.messages_dataset else args.pp,
             tg_counts=args.tg,
             exact_tg=args.exact_tg,
             depths=args.depth,
@@ -439,6 +453,7 @@ class BenchmarkConfig(BaseModel):
             adapt_prompt=args.adapt_prompt,
             enable_prefix_caching=args.enable_prefix_caching,
             book_url=args.book_url,
+            messages_dataset=args.messages_dataset,
             post_run_cmd=args.post_run_cmd,
             concurrency_levels=args.concurrency,
             save_result=args.save_result,

--- a/src/llama_benchy/corpus.py
+++ b/src/llama_benchy/corpus.py
@@ -32,10 +32,16 @@ class LightweightTokenizer:
 
 
 class TokenizedCorpus:
-    def __init__(self, book_url: str, tokenizer_name: Optional[str], model_name: str):
+    def __init__(
+        self,
+        book_url: str,
+        tokenizer_name: Optional[str],
+        model_name: str,
+        load_data: bool = True,
+    ):
         self.book_url = book_url
         self.tokenizer = self._get_tokenizer(model_name, tokenizer_name)
-        self.tokens = self._load_data()
+        self.tokens = self._load_data() if load_data else []
 
     def _get_transformers_tokenizer(self, name: str):
         from transformers import AutoTokenizer

--- a/src/llama_benchy/prompts.py
+++ b/src/llama_benchy/prompts.py
@@ -1,8 +1,29 @@
 import uuid
+import copy
+import json
+import os
 import numpy as np
-from typing import Tuple, List
+import requests
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, Tuple, List, Optional, cast
+from urllib.parse import parse_qs, urlsplit
 
 from .corpus import TokenizedCorpus
+
+
+@dataclass
+class PromptSample:
+    context_text: str
+    prompt_text: str
+    messages: Optional[List[Dict[str, Any]]] = None
+    tools: Optional[List[Dict[str, Any]]] = None
+
+    def __iter__(self) -> Iterator[str]:
+        # Preserve the historical (context, prompt) unpacking contract used by
+        # the prefix-caching runner paths. Conversation mode rejects those
+        # paths at CLI validation time.
+        yield self.context_text
+        yield self.prompt_text
 
 class PromptGenerator:
     def __init__(self, corpus: TokenizedCorpus):
@@ -52,3 +73,239 @@ class PromptGenerator:
         Generates a batch of (context, prompt) pairs.
         """
         return [self.generate(prompt_tokens, context_tokens, no_cache) for _ in range(batch_size)]
+
+
+class HuggingFaceConversationPromptGenerator:
+    """Load deterministic agent trajectories through the HF dataset server."""
+
+    def __init__(
+        self,
+        corpus: TokenizedCorpus,
+        selector: str,
+    ):
+        self.corpus = corpus
+        (
+            self.dataset,
+            self.dataset_config,
+            self.dataset_split,
+            instances,
+        ) = self._parse_selector(selector)
+        selections, self.dataset_revision = self._load_instances(instances)
+        self.row_ids = [int(item["row_id"]) for item in selections]
+        self.instance_ids = [str(item["instance_id"]) for item in selections]
+        self.trajectory_ids = [str(item["trajectory_id"]) for item in selections]
+        self.conversations = [
+            self._drop_trailing_assistant_messages(item["messages"])
+            for item in selections
+        ]
+        self.tools = [item["tools"] for item in selections]
+        if any(not messages for messages in self.conversations):
+            raise ValueError("a selected dataset row has no request-ending conversation")
+
+    @staticmethod
+    def _parse_selector(selector: str) -> Tuple[str, str, str, List[str]]:
+        parsed = urlsplit(selector)
+        dataset = parsed.path.strip("/")
+        params = parse_qs(parsed.query, keep_blank_values=True)
+        allowed = {"subset", "split", "instance_id"}
+        unknown = set(params) - allowed
+        if "/" not in dataset or unknown:
+            detail = f": {sorted(unknown)[0]}" if unknown else ""
+            raise ValueError(f"invalid dataset selector{detail}")
+        subset = params.get("subset", ["default"])
+        split = params.get("split", ["train"])
+        instances = list(dict.fromkeys(params.get("instance_id", [])))
+        if len(subset) != 1 or len(split) != 1 or not all(instances):
+            raise ValueError("dataset selector has invalid parameters")
+        if not instances:
+            raise ValueError("dataset selector requires instance_id")
+        return dataset, subset[0], split[0], instances
+
+    @staticmethod
+    def _drop_trailing_assistant_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        messages = list(messages)
+        while messages and messages[-1].get("role") == "assistant":
+            messages.pop()
+        return messages
+
+    @staticmethod
+    def _content_as_text(content: Any) -> str:
+        if isinstance(content, str):
+            return content
+        return json.dumps(content, ensure_ascii=False, separators=(",", ":"))
+
+    @staticmethod
+    def _dataset_revision(dataset: str) -> str:
+        response = requests.get(
+            f"https://huggingface.co/api/datasets/{dataset}", timeout=30
+        )
+        response.raise_for_status()
+        revision = response.json().get("sha")
+        if not isinstance(revision, str) or not revision:
+            raise ValueError(f"Hugging Face did not report a revision for {dataset}")
+        return revision
+
+    def _cache_path(self) -> str:
+        cache_dir = os.path.join(
+            os.path.expanduser("~"), ".cache", "llama-benchy", "datasets"
+        )
+        os.makedirs(cache_dir, exist_ok=True)
+        # Plain, human-readable name: dataset__config__split__instance[+instance].
+        # Deliberately NOT keyed on the live dataset revision: a cached
+        # trajectory stays reusable after the upstream dataset is updated
+        # (the datasets-server API may no longer serve the old split), and a
+        # cache hit needs no network access at all.
+        name = "__".join([
+            self.dataset.replace("/", "__"),
+            self.dataset_config,
+            self.dataset_split,
+            "+".join(self.instance_ids),
+        ])
+        return os.path.join(cache_dir, f"{name}.json")
+
+    def _load_instances(
+        self, instances: List[str]
+    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        self.instance_ids = instances
+        cache_path = self._cache_path()
+        if os.path.exists(cache_path):
+            with open(cache_path, "r", encoding="utf-8") as f:
+                cached = json.load(f)
+            # Legacy cache files are a bare list of selections (no revision).
+            if isinstance(cached, list):
+                return cast(List[Dict[str, Any]], cached), None
+            revision = cached.get("revision")
+            return (
+                cast(List[Dict[str, Any]], cached.get("selections", [])),
+                revision if isinstance(revision, str) else None,
+            )
+
+        revision = self._dataset_revision(self.dataset)
+        selections: List[Dict[str, Any]] = []
+        for instance in instances:
+            escaped = instance.replace("'", "''")
+            params: Dict[str, str | int] = {
+                "dataset": self.dataset,
+                "config": self.dataset_config,
+                "split": self.dataset_split,
+                "where": f'"instance_id" = \'{escaped}\'',
+                "length": 100,
+            }
+            response = requests.get(
+                "https://datasets-server.huggingface.co/filter",
+                params=params,
+                timeout=180,
+            )
+            response.raise_for_status()
+            body = response.json()
+            if body.get("error"):
+                raise ValueError(
+                    f"could not resolve dataset instance {instance}: {body['error']}"
+                )
+            candidates = body.get("rows", [])
+            if not candidates:
+                raise ValueError(
+                    f"dataset instance not found in {self.dataset_config}/{self.dataset_split}: "
+                    f"{instance}"
+                )
+            resolved = [
+                candidate for candidate in candidates
+                if candidate.get("row", {}).get("resolved") == 1
+            ]
+            pool = resolved or candidates
+            selected = min(
+                pool,
+                key=lambda candidate: (
+                    -len(candidate.get("row", {}).get("trajectory", [])),
+                    str(candidate.get("row", {}).get("trajectory_id", "")),
+                ),
+            )
+            row = selected.get("row", {})
+            trajectory_id = row.get("trajectory_id")
+            if not isinstance(trajectory_id, str) or not trajectory_id:
+                raise ValueError(f"dataset instance {instance} has no trajectory_id")
+            selections.append({
+                "row_id": int(selected["row_idx"]),
+                "instance_id": instance,
+                "trajectory_id": trajectory_id,
+                "messages": self._normalize_row(row, int(selected["row_idx"])),
+                "tools": self._normalize_tools(row, int(selected["row_idx"])),
+            })
+        with open(cache_path, "w", encoding="utf-8") as f:
+            json.dump({
+                "adapter_version": 4,
+                "dataset": self.dataset,
+                "config": self.dataset_config,
+                "split": self.dataset_split,
+                "instances": list(instances),
+                "revision": revision,
+                "selections": selections,
+            }, f, ensure_ascii=False)
+        print(f"Cached {len(selections)} dataset trajectories: {cache_path}")
+        return selections, revision
+
+    @staticmethod
+    def _normalize_row(row: Dict[str, Any], row_id: int) -> List[Dict[str, Any]]:
+        trajectory = row.get("trajectory")
+        if not isinstance(trajectory, list) or not trajectory:
+            raise ValueError(f"dataset row {row_id} has no trajectory array")
+        messages: List[Dict[str, Any]] = []
+        for entry in trajectory:
+            if not isinstance(entry, dict):
+                raise ValueError(f"dataset row {row_id} contains a non-object trajectory entry")
+            role = entry.get("role")
+            content = entry.get("content")
+            if not isinstance(role, str) or not isinstance(content, str):
+                raise ValueError(f"dataset row {row_id} contains an invalid trajectory entry")
+            message: Dict[str, Any] = {
+                "role": role,
+                "content": content,
+            }
+            if isinstance(entry.get("tool_calls"), list) and entry["tool_calls"]:
+                message["tool_calls"] = entry["tool_calls"]
+            messages.append(message)
+        return messages
+
+    @staticmethod
+    def _normalize_tools(row: Dict[str, Any], row_id: int) -> List[Dict[str, Any]]:
+        raw_tools = row.get("tools")
+        if not isinstance(raw_tools, list):
+            raise ValueError(f"dataset row {row_id} has no tools array")
+        tools: List[Dict[str, Any]] = []
+        for raw_tool in raw_tools:
+            try:
+                tool = json.loads(raw_tool) if isinstance(raw_tool, str) else raw_tool
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"dataset row {row_id} contains an invalid tool") from exc
+            if not isinstance(tool, dict):
+                raise ValueError(f"dataset row {row_id} contains an invalid tool")
+            tools.append(tool)
+        return tools
+
+    def generate_batch(
+        self,
+        batch_size: int,
+        prompt_tokens: int,
+        context_tokens: int = 0,
+        no_cache: bool = False,
+        run_index: int = 0,
+    ) -> List[PromptSample]:
+        if context_tokens:
+            raise ValueError("dataset conversations do not support --depth; use --depth 0")
+        if run_index < 0 or run_index >= len(self.conversations):
+            raise ValueError("dataset row index is out of range")
+        samples = []
+        for _ in range(batch_size):
+            messages = copy.deepcopy(self.conversations[run_index])
+            if no_cache:
+                nonce = f"\n<!-- llama-benchy nonce: {uuid.uuid4()} -->"
+                messages[0]["content"] = (
+                    self._content_as_text(messages[0].get("content")) + nonce
+                )
+            samples.append(PromptSample(
+                context_text="",
+                prompt_text="",
+                messages=messages,
+                tools=copy.deepcopy(self.tools[run_index]),
+            ))
+        return samples

--- a/src/llama_benchy/results.py
+++ b/src/llama_benchy/results.py
@@ -24,6 +24,8 @@ class BenchmarkMetadata(BaseModel):
     model: str = Field(..., description="Model name")
     prefix_caching_enabled: bool = Field(..., description="Whether prefix caching was enabled")
     max_concurrency: int = Field(..., description="Maximum concurrency level used in the suite")
+    prompt_source: Optional[str] = Field(None, description="Prompt source type or public dataset ID")
+    dataset_revision: Optional[str] = Field(None, description="Pinned Hugging Face dataset revision")
 
 class BenchmarkRun(BaseModel):
     concurrency: int = Field(..., description="Concurrency level for this run")
@@ -31,6 +33,7 @@ class BenchmarkRun(BaseModel):
     prompt_size: int = Field(..., description="Prompt size (tokens)")
     response_size: int = Field(..., description="Response size (tokens)")
     is_context_prefill_phase: bool = Field(..., description="Whether this was a context prefill phase run")
+    prompt_id: Optional[str] = Field(None, description="Resolved public prompt identifier")
     
     # Metrics (using BenchmarkMetric)
     pp_throughput: Optional[BenchmarkMetric] = Field(None, description="Prefill tokens per second (total)")
@@ -145,7 +148,9 @@ class BenchmarkResults:
             expected_pp_tokens: int,
             is_context_phase: bool = False,
             save_total_throughput_timeseries: bool = False,
-            save_all_throughput_timeseries: bool = False):
+            save_all_throughput_timeseries: bool = False,
+            prompt_id: Optional[str] = None,
+            use_observed_prompt_tokens: bool = False):
         
         if self.model_name is None:
             self.model_name = model
@@ -184,7 +189,8 @@ class BenchmarkResults:
                 save_total_throughput_timeseries=save_total_throughput_timeseries,
                 save_all_throughput_timeseries=save_all_throughput_timeseries,
                 agg_throughput_series=agg_throughput_series,
-                agg_req_throughput_series=agg_req_throughput_series
+                agg_req_throughput_series=agg_req_throughput_series,
+                use_observed_prompt_tokens=use_observed_prompt_tokens,
             )
 
         # Calculate metrics for BenchmarkRun
@@ -207,6 +213,7 @@ class BenchmarkResults:
             prompt_size=pp, # Configured prompt size
             response_size=tg,
             is_context_prefill_phase=is_context_phase,
+            prompt_id=prompt_id,
             pp_throughput=run_metric_pp_throughput,
             pp_req_throughput=run_metric_pp_req_throughput,
             tg_throughput=run_metric_tg_throughput,
@@ -237,7 +244,8 @@ class BenchmarkResults:
                        save_total_throughput_timeseries: bool = False,
                        save_all_throughput_timeseries: bool = False,
                        agg_throughput_series: Optional[List[TimeSeries]] = None,
-                       agg_req_throughput_series: Optional[List[List[TimeSeries]]] = None):
+                       agg_req_throughput_series: Optional[List[List[TimeSeries]]] = None,
+                       use_observed_prompt_tokens: bool = False):
         
         valid_results = [r for r in results if r and not r.error]
         if not valid_results:
@@ -283,7 +291,7 @@ class BenchmarkResults:
             prompt_tokens = expected_pp_tokens
             if res.prompt_tokens > 0:
                 diff = abs(res.prompt_tokens - expected_pp_tokens)
-                if diff < expected_pp_tokens * 0.2:
+                if use_observed_prompt_tokens or diff < expected_pp_tokens * 0.2:
                     prompt_tokens = res.prompt_tokens
             
             batch_prompt_tokens += prompt_tokens
@@ -303,7 +311,7 @@ class BenchmarkResults:
                 first_token_times.append(res.first_token_ts)
                 e2e_ttft = res.first_token_ts - res.start_ts
                 ttft = max(0, e2e_ttft - latency)
-                est_ppt = max(0, ttfr - latency)
+                est_ppt = ttft
 
                 agg_e2e_ttft_values.append(e2e_ttft)
                 agg_ttft_values.append(ttft)
@@ -401,12 +409,13 @@ class BenchmarkResults:
             else:
                 # Standard Phase
                 d_suffix = f" @ d{run.context_size}" if run.context_size > 0 else ""
+                row_prefix = f"{run.prompt_id} " if run.prompt_id else ""
                 
                 # Prompt Processing
                 if run.pp_throughput:
                     rows.append({
                         "model": self.model_name or "Unknown",
-                        "test_name": f"pp{run.prompt_size}{d_suffix}{c_suffix}",
+                        "test_name": f"{row_prefix}pp{run.prompt_size}{d_suffix}{c_suffix}",
                         "t_s": run.pp_throughput,
                         "t_s_req": run.pp_req_throughput,
                         "peak_ts": None,
@@ -420,7 +429,7 @@ class BenchmarkResults:
                 if run.tg_throughput or run.peak_throughput:
                     rows.append({
                         "model": self.model_name or "Unknown",
-                        "test_name": f"tg{run.response_size}{d_suffix}{c_suffix}",
+                        "test_name": f"{row_prefix}tg{run.response_size}{d_suffix}{c_suffix}",
                         "t_s": run.tg_throughput,
                         "t_s_req": run.tg_req_throughput,
                         "peak_ts": run.peak_throughput,

--- a/src/llama_benchy/runner.py
+++ b/src/llama_benchy/runner.py
@@ -3,20 +3,32 @@ import subprocess
 import time
 import sys
 from datetime import datetime, timezone
-from typing import List
+from typing import List, Sequence, Tuple
 import aiohttp
 
 from ._version import __version__
 from .config import BenchmarkConfig
 from .client import CONTEXT_LOAD_USER_MESSAGE, LLMClient
-from .prompts import PromptGenerator
+from .prompts import (
+    HuggingFaceConversationPromptGenerator,
+    PromptGenerator,
+    PromptSample,
+)
 from .results import BenchmarkResults, BenchmarkMetadata
 
 class BenchmarkFailure(Exception):
     pass
 
 class BenchmarkRunner:
-    def __init__(self, config: BenchmarkConfig, client: LLMClient, prompt_generator: PromptGenerator, progress=None):
+    def __init__(
+        self,
+        config: BenchmarkConfig,
+        client: LLMClient,
+        prompt_generator: (
+            PromptGenerator | HuggingFaceConversationPromptGenerator
+        ),
+        progress=None,
+    ):
         self.config = config
         self.client = client
         self.prompt_gen = prompt_generator
@@ -32,6 +44,24 @@ class BenchmarkRunner:
         rid = self._next_request_id
         self._next_request_id += 1
         return rid
+
+    def _metadata(self, latency: float, max_concurrency: int) -> BenchmarkMetadata:
+        prompt_source = None
+        dataset_revision = None
+        if isinstance(self.prompt_gen, HuggingFaceConversationPromptGenerator):
+            prompt_source = self.config.messages_dataset
+            dataset_revision = self.prompt_gen.dataset_revision
+        return BenchmarkMetadata(
+            version=__version__,
+            timestamp=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ"),
+            latency_mode=self.config.latency_mode,
+            latency_ms=latency * 1000,
+            model=self.config.model,
+            prefix_caching_enabled=self.config.enable_prefix_caching,
+            max_concurrency=max_concurrency,
+            prompt_source=prompt_source,
+            dataset_revision=dataset_revision,
+        )
 
     def _emit_request_start(self, request_id: int, pp: int, tg: int, depth: int, concurrency: int, run_index: int) -> None:
         if self.progress is None:
@@ -98,21 +128,38 @@ class BenchmarkRunner:
                     for pp in self.config.pp_counts:
                         for tg in self.config.tg_counts:
                             for concurrency in self.config.concurrency_levels:
-                                print(f"Running test: pp={pp}, tg={tg}, depth={depth}, concurrency={concurrency}")
+                                if isinstance(
+                                    self.prompt_gen,
+                                    HuggingFaceConversationPromptGenerator,
+                                ):
+                                    print(
+                                        f"Running dataset instances: {self.prompt_gen.instance_ids}, "
+                                        f"tg cap={tg}, concurrency={concurrency}"
+                                    )
+                                else:
+                                    print(f"Running test: pp={pp}, tg={tg}, depth={depth}, concurrency={concurrency}")
 
                                 run_std_results = []
                                 run_ctx_results = []
                                 expected_pp = pp
                                 expected_ctx = depth
 
-                                total_runs = self.config.num_runs + warmup_runs
+                                measured_runs = (
+                                    len(self.prompt_gen.row_ids)
+                                    if isinstance(
+                                        self.prompt_gen,
+                                        HuggingFaceConversationPromptGenerator,
+                                    )
+                                    else self.config.num_runs
+                                )
+                                total_runs = measured_runs + warmup_runs
                                 for run in range(total_runs):
                                     is_warmup = run < warmup_runs
                                     measured_run_index = run - warmup_runs
                                     run_label = (
                                         f"Warmup {run + 1}/{warmup_runs}"
                                         if is_warmup
-                                        else f"Run {measured_run_index + 1}/{self.config.num_runs}"
+                                        else f"Run {measured_run_index + 1}/{measured_runs}"
                                     )
 
                                     # Adapt prompt tokens
@@ -127,12 +174,25 @@ class BenchmarkRunner:
                                     expected_pp = current_pp
                                     expected_ctx = current_depth
 
-                                    prompt_batch = self.prompt_gen.generate_batch(
-                                        concurrency,
-                                        current_pp,
-                                        current_depth,
-                                        self.config.no_cache
-                                    )
+                                    prompt_batch: Sequence[Tuple[str, str] | PromptSample]
+                                    if isinstance(
+                                        self.prompt_gen,
+                                        HuggingFaceConversationPromptGenerator,
+                                    ):
+                                        prompt_batch = self.prompt_gen.generate_batch(
+                                            concurrency,
+                                            current_pp,
+                                            current_depth,
+                                            self.config.no_cache,
+                                            run_index=max(0, measured_run_index),
+                                        )
+                                    else:
+                                        prompt_batch = self.prompt_gen.generate_batch(
+                                            concurrency,
+                                            current_pp,
+                                            current_depth,
+                                            self.config.no_cache,
+                                        )
 
                                     if self.config.enable_prefix_caching and depth > 0:
                                         # Phase 1: Context Load
@@ -197,12 +257,20 @@ class BenchmarkRunner:
                                         expected_tokens = current_pp + current_depth
                                         batch_tasks = []
                                         for i in range(concurrency):
-                                            context, prompt = prompt_batch[i]
+                                            sample = prompt_batch[i]
+                                            if isinstance(sample, PromptSample):
+                                                context = sample.context_text
+                                                prompt = sample.prompt_text
+                                                messages = sample.messages
+                                                tools = sample.tools
+                                            else:
+                                                context, prompt = sample
+                                                messages = None
+                                                tools = None
                                             if not is_warmup:
                                                 rid = self._new_request_id()
                                                 self._emit_request_start(rid, pp, tg, depth, concurrency, measured_run_index)
-                                            batch_tasks.append(self.client.run_generation(
-                                                session,
+                                            generation_kwargs = dict(
                                                 context_text=context,
                                                 prompt_text=prompt,
                                                 max_tokens=tg,
@@ -210,6 +278,13 @@ class BenchmarkRunner:
                                                 tokenizer=tokenizer,
                                                 progress=None if is_warmup else self.progress,
                                                 request_id=None if is_warmup else rid,
+                                            )
+                                            if messages is not None:
+                                                generation_kwargs["messages"] = messages
+                                            if tools is not None:
+                                                generation_kwargs["tools"] = tools
+                                            batch_tasks.append(self.client.run_generation(
+                                                session, **generation_kwargs
                                             ))
 
                                         batch_results = await asyncio.gather(*batch_tasks)
@@ -230,7 +305,36 @@ class BenchmarkRunner:
                                             print(f"Post-run command failed: {e}")
 
                                 # Aggregate and Record
-                                if self.config.enable_prefix_caching and depth > 0:
+                                if isinstance(
+                                    self.prompt_gen,
+                                    HuggingFaceConversationPromptGenerator,
+                                ):
+                                    for row_index, batch in enumerate(run_std_results):
+                                        actual_pp = round(sum(
+                                            result.prompt_tokens for result in batch
+                                        ) / len(batch))
+                                        actual_tg = round(sum(
+                                            result.total_tokens for result in batch
+                                        ) / len(batch))
+                                        self.results.add(
+                                            self.config.model,
+                                            actual_pp,
+                                            actual_tg,
+                                            0,
+                                            concurrency,
+                                            [batch],
+                                            latency,
+                                            actual_pp,
+                                            is_context_phase=False,
+                                            save_total_throughput_timeseries=self.config.save_total_throughput_timeseries,
+                                            save_all_throughput_timeseries=self.config.save_all_throughput_timeseries,
+                                            prompt_id=(
+                                                f"{self.prompt_gen.instance_ids[row_index]}@"
+                                                f"{self.prompt_gen.trajectory_ids[row_index]}"
+                                            ),
+                                            use_observed_prompt_tokens=True,
+                                        )
+                                elif self.config.enable_prefix_caching and depth > 0:
                                     self.results.add(self.config.model, pp, tg, depth, concurrency, run_ctx_results, latency, expected_ctx, is_context_phase=True, save_total_throughput_timeseries=self.config.save_total_throughput_timeseries, save_all_throughput_timeseries=self.config.save_all_throughput_timeseries)
                                     self.results.add(self.config.model, pp, tg, depth, concurrency, run_std_results, latency, expected_pp, is_context_phase=False, save_total_throughput_timeseries=self.config.save_total_throughput_timeseries, save_all_throughput_timeseries=self.config.save_all_throughput_timeseries)
                                 else:
@@ -238,15 +342,7 @@ class BenchmarkRunner:
                                     # In the loop above: expected_tokens = current_pp + current_depth
                                     self.results.add(self.config.model, pp, tg, depth, concurrency, run_std_results, latency, expected_pp + expected_ctx, is_context_phase=False, save_total_throughput_timeseries=self.config.save_total_throughput_timeseries, save_all_throughput_timeseries=self.config.save_all_throughput_timeseries)
 
-                self.results.metadata = BenchmarkMetadata(
-                    version=__version__,
-                    timestamp=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ"),
-                    latency_mode=self.config.latency_mode,
-                    latency_ms=latency * 1000,
-                    model=self.config.model,
-                    prefix_caching_enabled=self.config.enable_prefix_caching,
-                    max_concurrency=max(self.config.concurrency_levels) if self.config.concurrency_levels else 1
-                )
+                self.results.metadata = self._metadata(latency, max_concurrency)
 
             self.results.save_report(self.config.save_result, self.config.result_format, max(self.config.concurrency_levels) if self.config.concurrency_levels else 1)
 
@@ -260,15 +356,7 @@ class BenchmarkRunner:
                 if should_save:
                     print("\n[Interrupted/Failed] Saving partial results...")
                     if self.results.metadata is None:
-                        self.results.metadata = BenchmarkMetadata(
-                            version=__version__,
-                            timestamp=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ"),
-                            latency_mode=self.config.latency_mode,
-                            latency_ms=latency * 1000,
-                            model=self.config.model,
-                            prefix_caching_enabled=self.config.enable_prefix_caching,
-                            max_concurrency=max_concurrency
-                        )
+                        self.results.metadata = self._metadata(latency, max_concurrency)
                     self.results.save_report(self.config.save_result, self.config.result_format, max_concurrency)
             
             if isinstance(e, BenchmarkFailure):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -110,6 +110,22 @@ def _content_event(content, token_ids=_MISSING):
     return {"choices": [choice]}
 
 
+def _tool_call_event(arguments, token_ids=_MISSING):
+    choice = {
+        "index": 0,
+        "delta": {
+            "tool_calls": [{
+                "index": 0,
+                "function": {"arguments": arguments},
+            }],
+        },
+        "finish_reason": None,
+    }
+    if token_ids is not _MISSING:
+        choice["token_ids"] = token_ids
+    return {"choices": [choice]}
+
+
 def _usage_event(completion_tokens):
     return {
         "choices": [],
@@ -167,6 +183,17 @@ def test_generation_payload_merges_extra_body():
     assert payload["ignore_eos"] is True
 
 
+def test_generation_payload_preserves_tools():
+    client = LLMClient("http://example.test/v1", "EMPTY", "model")
+    tools = [{"type": "function", "function": {"name": "bash"}}]
+
+    payload = client._build_generation_payload(
+        [], max_tokens=128, no_cache=False, tools=tools
+    )
+
+    assert payload["tools"] == tools
+
+
 def test_exact_tg_forces_min_tokens_and_ignore_eos():
     client = LLMClient(
         "http://example.test/v1",
@@ -202,6 +229,29 @@ async def test_run_generation_replaces_empty_user_message_with_context_probe():
         {"role": "user", "content": CONTEXT_LOAD_USER_MESSAGE},
     ]
     assert messages[-1]["content"].strip()
+
+
+@pytest.mark.asyncio
+async def test_run_generation_preserves_explicit_conversation_messages():
+    client = LLMClient("http://example.test/v1", "EMPTY", "model")
+    session = _FakeSession([_sse_event("[DONE]")])
+    messages = [
+        {"role": "system", "content": "bootstrap"},
+        {"role": "user", "content": "inspect the repository"},
+        {"role": "assistant", "content": "I inspected it."},
+        {"role": "user", "content": "now fix the tests"},
+    ]
+
+    await client.run_generation(
+        session,
+        context_text="ignored",
+        prompt_text="ignored",
+        max_tokens=8,
+        no_cache=False,
+        messages=messages,
+    )
+
+    assert session.requests[0]["kwargs"]["json"]["messages"] == messages
 
 
 @pytest.mark.asyncio
@@ -266,6 +316,39 @@ async def test_streaming_uses_final_usage_when_token_ids_are_missing():
     assert result.total_tokens == 2
     assert len(result.token_timestamps) == 2
     assert tokenizer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_streaming_times_tool_call_argument_deltas():
+    result = await _run_stream([
+        _tool_call_event('{"command":'),
+        _tool_call_event('"pytest"}'),
+        _usage_event(12),
+        "[DONE]",
+    ])
+
+    assert result.prompt_tokens == 16
+    assert result.total_tokens == 12
+    assert result.first_token_ts is not None
+    assert len(result.token_timestamps) == 12
+    assert result.token_timestamps[0] <= result.token_timestamps[-1]
+
+
+@pytest.mark.asyncio
+async def test_streaming_prefers_server_reported_decode_duration():
+    usage = _usage_event(10)
+    usage["timings"] = {"decode_ms": 2000.0}
+
+    result = await _run_stream([
+        _content_event("buffered response"),
+        usage,
+        "[DONE]",
+    ])
+
+    assert result.server_decode_seconds == pytest.approx(2.0)
+    assert result.total_tokens == 10
+    assert len(result.token_timestamps) == 10
+    assert result.token_timestamps[-1] - result.token_timestamps[0] == pytest.approx(1.8)
 
 
 @pytest.mark.asyncio

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,221 @@
+import json
+
+import pytest
+
+from llama_benchy.prompts import (
+    HuggingFaceConversationPromptGenerator,
+)
+
+
+class _CharTokenizer:
+    def encode(self, text, add_special_tokens=False):
+        return [ord(char) for char in text]
+
+    def decode(self, token_ids):
+        return "".join(chr(token) for token in token_ids)
+
+
+class _Corpus:
+    def __init__(self):
+        self.tokenizer = _CharTokenizer()
+
+    def get_tokenizer(self):
+        return self.tokenizer
+
+
+def test_conversation_prompt_drops_completed_assistant_response():
+    assert HuggingFaceConversationPromptGenerator._drop_trailing_assistant_messages([
+        {"role": "user", "content": "request"},
+        {"role": "assistant", "content": "done"},
+    ]) == [{"role": "user", "content": "request"}]
+
+
+def test_huggingface_open_swe_normalization_preserves_tool_calls():
+    tool_calls = [{
+        "id": "call-1",
+        "type": "function",
+        "function": {"name": "bash", "arguments": "{\"command\":\"ls\"}"},
+    }]
+    messages = HuggingFaceConversationPromptGenerator._normalize_row({
+        "trajectory": [
+            {"role": "system", "content": "bootstrap"},
+            {"role": "user", "content": "fix it"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "inspect first",
+                "tool_calls": tool_calls,
+            },
+            {"role": "tool", "content": "files"},
+        ]
+    }, 8)
+
+    assert messages[2] == {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": tool_calls,
+    }
+    assert messages[3] == {"role": "tool", "content": "files"}
+
+
+def test_huggingface_open_swe_normalization_preserves_tools():
+    tool = {
+        "type": "function",
+        "function": {"name": "bash", "parameters": {"type": "object"}},
+    }
+    assert HuggingFaceConversationPromptGenerator._normalize_tools(
+        {"tools": [json.dumps(tool)]}, 8
+    ) == [tool]
+
+
+def test_huggingface_generator_resolves_instances_and_sends_full_rows(monkeypatch, tmp_path):
+    class _Response:
+        def __init__(self, body):
+            self.body = body
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.body
+
+    def fake_get(url, **kwargs):
+        if "/api/datasets/" in url:
+            return _Response({"sha": "revision-1"})
+        instance = "task-1" if "task-1" in kwargs["params"]["where"] else "task-0"
+        row_id = int(instance[-1])
+        trajectory = [
+            {"role": "system", "content": "boot"},
+            {"role": "user", "content": f"request-{row_id}" + "x" * 1000},
+            {"role": "assistant", "content": "completed"},
+        ]
+        return _Response({"rows": [
+            {"row_idx": row_id + 10, "row": {
+                "trajectory_id": "unresolved-longer",
+                "resolved": 0,
+                "trajectory": trajectory * 2,
+            }},
+            {"row_idx": row_id, "row": {
+                "trajectory_id": f"trajectory-{row_id}",
+                "resolved": 1,
+                "trajectory": trajectory,
+                "tools": [json.dumps({
+                    "type": "function",
+                    "function": {"name": f"tool-{row_id}"},
+                })],
+            }},
+        ]})
+
+    monkeypatch.setattr("llama_benchy.prompts.requests.get", fake_get)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    generator = HuggingFaceConversationPromptGenerator(
+        _Corpus(), "owner/dataset?instance_id=task-0&instance_id=task-1"
+    )
+
+    warmup = generator.generate_batch(1, 20, run_index=0)[0]
+    measured_zero = generator.generate_batch(1, 20, run_index=0)[0]
+    measured_one = generator.generate_batch(1, 20, run_index=1)[0]
+    concurrent = generator.generate_batch(2, 20, run_index=0)
+
+    assert warmup.messages == measured_zero.messages
+    assert measured_zero.messages[-1]["content"].startswith("request-0")
+    assert measured_one.messages[-1]["content"].startswith("request-1")
+    assert measured_zero.tools[0]["function"]["name"] == "tool-0"
+    assert measured_one.tools[0]["function"]["name"] == "tool-1"
+    assert [sample.messages[-1]["content"][:9] for sample in concurrent] == [
+        "request-0", "request-0"
+    ]
+    with pytest.raises(ValueError, match="dataset row index is out of range"):
+        generator.generate_batch(1, 20, run_index=2)
+    assert generator.row_ids == [0, 1]
+    assert generator.trajectory_ids == ["trajectory-0", "trajectory-1"]
+    assert generator.dataset_revision == "revision-1"
+
+
+def test_huggingface_selector_accepts_repeated_instance_ids():
+    assert HuggingFaceConversationPromptGenerator._parse_selector(
+        "nvidia/Open-SWE-Traces?subset=openhands&split=qwen35_122b"
+        "&instance_id=task-a&instance_id=task-b"
+    ) == (
+        "nvidia/Open-SWE-Traces",
+        "openhands",
+        "qwen35_122b",
+        ["task-a", "task-b"],
+    )
+
+
+def test_huggingface_generator_cache_hit_is_offline_and_plain_named(monkeypatch, tmp_path):
+    class _Response:
+        def __init__(self, body):
+            self.body = body
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.body
+
+    def fake_get(url, **kwargs):
+        if "/api/datasets/" in url:
+            return _Response({"sha": "revision-1"})
+        row = {
+            "trajectory_id": "trajectory-0",
+            "resolved": 1,
+            "trajectory": [
+                {"role": "system", "content": "boot"},
+                {"role": "user", "content": "request-0"},
+                {"role": "assistant", "content": "completed"},
+            ],
+            "tools": [],
+        }
+        return _Response({"rows": [{"row_idx": 0, "row": row}]})
+
+    monkeypatch.setattr("llama_benchy.prompts.requests.get", fake_get)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    selector = "owner/dataset?instance_id=task-0"
+    generator = HuggingFaceConversationPromptGenerator(_Corpus(), selector)
+
+    # Cache file is plain-named (not a content hash).
+    cache_dir = tmp_path / ".cache" / "llama-benchy" / "datasets"
+    assert [f.name for f in cache_dir.iterdir()] == [
+        "owner__dataset__default__train__task-0.json"
+    ]
+    assert generator.dataset_revision == "revision-1"
+
+    # A second load from the same cache must not touch the network at all,
+    # even if the upstream dataset revision has changed or the API is down.
+    def offline_get(url, **kwargs):
+        raise AssertionError(f"cache hit must not call the network: {url}")
+
+    monkeypatch.setattr("llama_benchy.prompts.requests.get", offline_get)
+    warm = HuggingFaceConversationPromptGenerator(_Corpus(), selector)
+    assert warm.dataset_revision == "revision-1"
+    assert warm.row_ids == generator.row_ids
+    assert warm.trajectory_ids == generator.trajectory_ids
+
+
+def test_huggingface_generator_accepts_legacy_bare_list_cache(monkeypatch, tmp_path):
+    # Legacy cache files (pre-plain-naming) are a bare list of selections
+    # with no revision metadata; they must still load, offline.
+    def offline_get(url, **kwargs):
+        raise AssertionError(f"cache hit must not call the network: {url}")
+
+    monkeypatch.setattr("llama_benchy.prompts.requests.get", offline_get)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cache_dir = tmp_path / ".cache" / "llama-benchy" / "datasets"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "owner__dataset__default__train__task-0.json").write_text(json.dumps([
+        {
+            "row_id": 0,
+            "instance_id": "task-0",
+            "trajectory_id": "trajectory-0",
+            "messages": [{"role": "user", "content": "request-0"}],
+            "tools": [],
+        }
+    ]))
+    generator = HuggingFaceConversationPromptGenerator(
+        _Corpus(), "owner/dataset?instance_id=task-0"
+    )
+    assert generator.dataset_revision is None
+    assert generator.row_ids == [0]
+    assert generator.trajectory_ids == ["trajectory-0"]

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -67,3 +67,102 @@ def test_block_streaming_excludes_first_observed_block_from_decode_throughput():
     run = results.runs[0]
     assert run.tg_throughput is not None
     assert run.tg_throughput.mean == pytest.approx(256.0)
+
+
+def test_prefill_throughput_uses_first_content_token_not_empty_response():
+    result = RequestResult(
+        start_ts=0.0,
+        first_response_ts=0.01,
+        first_token_ts=2.0,
+        end_ts=2.2,
+        prompt_tokens=2_000,
+        total_tokens=3,
+        token_timestamps=[2.0, 2.1, 2.2],
+    )
+
+    results = BenchmarkResults()
+    results.add(
+        "model",
+        2_000,
+        3,
+        0,
+        1,
+        [[result]],
+        latency=0.1,
+        expected_pp_tokens=2_000,
+    )
+
+    run = results.runs[0]
+    assert run.ttfr is not None
+    assert run.ttfr.mean == pytest.approx(10.0)
+    assert run.est_ppt is not None
+    assert run.est_ppt.mean == pytest.approx(1_900.0)
+    assert run.pp_throughput is not None
+    assert run.pp_throughput.mean == pytest.approx(2_000 / 1.9)
+
+
+def test_dataset_run_reports_observed_sizes_and_prompt_id():
+    result = RequestResult(
+        start_ts=0.0,
+        first_response_ts=1.0,
+        first_token_ts=1.1,
+        end_ts=1.4,
+        prompt_tokens=25_711,
+        total_tokens=309,
+        token_timestamps=[1.1, 1.2, 1.3],
+    )
+
+    results = BenchmarkResults()
+    results.add(
+        "model",
+        25_711,
+        309,
+        0,
+        1,
+        [[result]],
+        latency=0.0,
+        expected_pp_tokens=25_711,
+        prompt_id="task@trajectory",
+    )
+
+    run = results.runs[0]
+    assert (run.prompt_id, run.prompt_size, run.response_size) == (
+        "task@trajectory", 25_711, 309
+    )
+    assert {row["test_name"] for row in results._generate_rows()} == {
+        "task@trajectory pp25711",
+        "task@trajectory tg309",
+    }
+
+
+def test_dataset_concurrency_uses_each_requests_observed_prompt_size():
+    first = RequestResult(
+        start_ts=0.0,
+        first_response_ts=0.01,
+        first_token_ts=1.0,
+        end_ts=1.2,
+        prompt_tokens=100,
+        total_tokens=3,
+        token_timestamps=[1.0, 1.1, 1.2],
+    )
+    second = RequestResult(
+        start_ts=0.0,
+        first_response_ts=0.01,
+        first_token_ts=2.0,
+        end_ts=2.2,
+        prompt_tokens=500,
+        total_tokens=3,
+        token_timestamps=[2.0, 2.1, 2.2],
+    )
+
+    results = BenchmarkResults()
+    results.add(
+        "model", 300, 3, 0, 2, [[first, second]], 0.0, 300,
+        use_observed_prompt_tokens=True,
+    )
+
+    run = results.runs[0]
+    assert run.pp_throughput is not None
+    assert run.pp_throughput.mean == pytest.approx(300.0)
+    assert run.pp_req_throughput is not None
+    assert run.pp_req_throughput.mean == pytest.approx(175.0)


### PR DESCRIPTION
I have added the ability to use some hugging face data sets in particular

[](https://huggingface.co/datasets/nvidia/Open-SWE-Traces)

If find it useful to see how it will perform closer to real world data.  I used this on my benchmarks here:

[](https://youtu.be/q48bLlw4mVw?t=281&si=z2m5_iBayhLwCiNP) at 04:41

So I pick like 6 traces, and run llama-benchy.

<img width="2263" height="1160" alt="Screenshot 2026-08-04 at 11 32 51 AM" src="https://github.com/user-attachments/assets/7de8dbcd-fe94-4303-b3c6-bda6877bd131" />

Caveat:  It may error depending on Hugging Face api.  I encountered this a few times, there is now a way to cache the HF datasets to reduce this errors.

Please let me know if want this changed.